### PR TITLE
added species options from Lorwyn: First Light

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ _Mordenkainen Presents: Monsters of the Multiverse_ © 2022 Wizards of the Coast
 _Spelljammer: Adventures in Space_ © 2022 Wizards of the Coast LLC.
 
 _Player's Handbook (2024)_ © 2024 Wizards of the Coast LLC.
+
+_Lorwyn: First Light_ © 2025 Wizards of the Coast LLC.

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -16,7 +16,7 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 **New associations have been established for legacy species based on mixed parentage.** Specifically, this document considers the Half-Elf and Half-Orc species to be ancestries of Elves and Orcs respectively. These two species options have been removed as player options as of _SRD 5.2_, but they will remain in this document, as all species and ancestry options remain supported by the core game rules, even if in older superseded or legacy sources.
 
-**The Boggart, Bugbear, Goblin, Hobgoblin, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
+**The Boggart, Bugbear, Goblin, Hobgoblin, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of several variants having a Goblinoid creature tag and the Fey Ancestry trait.
 
 **The Dhampir, Ixalan Vampire, and Zendikar Vampire are grouped together as ancestries of a Vampire species**, based on the Dhampir fulfilling a similar archetypal fantasy role and narrative origin as Vampires.
 
@@ -65,7 +65,7 @@ Someone probably does! This document can also just act as a dice-driven randomiz
 
 **Method 1:** Select the die with the next-highest value, and re-roll for any results not on the table. For example, a d6 can be rolled for a d5 table, with a 6 requiring a re-roll.
 
-**Method 2:** As with rolling percentile dice, roll for each digit. For example, if the **Reincarnation Options** table has 54 results, first roll for the tens position (in this example, the tens position has six options, so roll a d6 and consider a 6 to be a 0), then for the ones position with a d10, rerolling an individual die if it creates an invalid result, such as a 56 or 00 (which would be 60).
+**Method 2:** As with rolling percentile dice, roll for each digit. For example, if the **Reincarnation Options** table has 57 results, first roll for the tens position (in this example, the tens position has six options, so roll a d6 and consider a 6 to be a 0), then for the ones position with a d10, re-rolling an individual die if it creates an invalid result, such as a 58 or 00.
 
 ---
 

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -65,7 +65,7 @@ Someone probably does! This document can also just act as a dice-driven randomiz
 
 **Method 1:** Select the die with the next-highest value, and re-roll for any results not on the table. For example, a d6 can be rolled for a d5 table, with a 6 requiring a re-roll.
 
-**Method 2:** As with rolling percentile dice, roll for each digit. For example, if the **Reincarnation Options** table has 57 results, first roll for the tens position (in this example, the tens position has six options, so roll a d6 and consider a 6 to be a 0), then for the ones position with a d10, re-rolling an individual die if it creates an invalid result, such as a 58 or 00.
+**Method 2:** As with rolling percentile dice, roll for each digit. For example, if the **Reincarnation Options** table has 57 results, first roll for the tens position (in this example, the tens position has six options, so roll a d6 and consider a 6 to be a 0), then for the ones position with a d10. Roll an individual die again if it creates an invalid total result, such as a 58 or 00.
 
 ---
 

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -16,7 +16,7 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 **New associations have been established for legacy species based on mixed parentage.** Specifically, this document considers the Half-Elf and Half-Orc species to be ancestries of Elves and Orcs respectively. These two species options have been removed as player options as of _SRD 5.2_, but they will remain in this document, as all species and ancestry options remain supported by the core game rules, even if in older superseded or legacy sources.
 
-**Boggarts, Bugbears, Goblins, Hobgoblins, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
+**The Boggart, Bugbear, Goblin, Hobgoblin, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
 
 **The Dhampir, Ixalan Vampire, and Zendikar Vampire are grouped together as ancestries of a Vampire species**, based on the Dhampir fulfilling a similar archetypal fantasy role and narrative origin as Vampires.
 

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -8,9 +8,10 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 ## How to use these tables
 
-1. When you cast _Reincarnate_, roll on the **[Reincarnation Options](ch-2-reincarnate.md#reincarnation-options)** table to determine your species.
-2. If a species has multiple options, that entry will reference a subsequent table to roll on, which will determine your specific variant. If a species has limited variant options in one or more settings, roll for setting, then roll for variant within the resulting setting, or on its multiverse table for general options.
-3. Continue to follow any instructions for rolling on subsequent tables until you reach a final result, which reflects the species of your newly reincarnated body.
+1. When you cast _Reincarnate_ targeting a dead creature or piece of one, the target can be any creature type represented by a species, ancestry, or variant in any of the **[Reincarnation Options](ch-2-reincarnate.md#reincarnation-options)** tables: **Construct**, **Fey**, **Humanoid**, **Monstrosity**, or **Ooze**.
+2. After casting _Reincarnate_, roll on the **[Reincarnation Options](ch-2-reincarnate.md#reincarnation-options)** table to determine your species.
+3. If a species has multiple options, that entry will reference a subsequent table to roll on, which will determine your specific variant. If a species has limited variant options in one or more settings, roll for setting, then roll for variant within the resulting setting, or on its multiverse table for general options.
+4. Continue to follow any instructions for rolling on subsequent tables until you reach a final result, which reflects the species of your newly reincarnated body.
 
 ## Assumptions
 

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -16,11 +16,13 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 **New associations have been established for legacy species based on mixed parentage.** Specifically, this document considers the Half-Elf and Half-Orc species to be ancestries of Elves and Orcs respectively. These two species options have been removed as player options as of _SRD 5.2_, but they will remain in this document, as all species and ancestry options remain supported by the core game rules, even if in older superseded or legacy sources.
 
-**Bugbears, Goblins, Hobgoblins, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
+**Boggarts, Bugbears, Goblins, Hobgoblins, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
 
 **The lineages from _Van Richten's Guide to Ravenloft_ are not considered to be ancestries of a common species.** While they have shared mechanics for character creation or conversion, they have no actual shared origin in lore and thus are treated as separate species.
 
 **The Dhampir is considered to be a Vampire variant**, based on it fulfilling a similar archetypal fantasy role and narrative origin.
+
+**Species adapted from other species with no connections in lore are listed as separate entries.** This includes the Flamekin from _Lorwyn: First Light_, which uses the Fire Genasi for its traits but is otherwise narratively unrelated to Genasi. A footnote will list how these adapted species are mechanically connected to their source species.
 
 ### Sourcing
 

--- a/ch-1-thesis.md
+++ b/ch-1-thesis.md
@@ -8,7 +8,7 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 ## Assumptions
 
-### Grouping and separating
+### Grouping
 
 **Related ancestries are grouped together under a common species for organizational purposes.** This does not align with the options presented in some book releases, where classically grouped ancestries are split out into discrete species options (e.g. Eladrin, Sea Elves, and Shadar-kai are all considered types of Elves in _Mordenkainen's Tome of Foes_, but are separate species in _Mordenkainen Presents: Monsters of the Multiverse_), but this setup helps keep the top-level table under control, it acknowledges that these separate branches of people have a common ancestry with shared traits, and it prevents the odds from being stacked in the favor of more diverse species such as Elves or Dragonborn.
 
@@ -18,9 +18,11 @@ Additionally, **Dungeon Masters should be empowered to apply custom weighting of
 
 **Boggarts, Bugbears, Goblins, Hobgoblins, and Verdan are grouped together as ancestries of a Goblinoid species**, due to their peoples' connections in lore, and in recognition of recent game updates giving many of them the shared "Goblinoid" creature tag and the Fey Ancestry trait.
 
-**The lineages from _Van Richten's Guide to Ravenloft_ are not considered to be ancestries of a common species.** While they have shared mechanics for character creation or conversion, they have no actual shared origin in lore and thus are treated as separate species.
+**The Dhampir, Ixalan Vampire, and Zendikar Vampire are grouped together as ancestries of a Vampire species**, based on the Dhampir fulfilling a similar archetypal fantasy role and narrative origin as Vampires.
 
-**The Dhampir is considered to be a Vampire variant**, based on it fulfilling a similar archetypal fantasy role and narrative origin.
+### Separating
+
+**The lineages from _Van Richten's Guide to Ravenloft_ are not considered to be ancestries of a common species.** While they have shared mechanics for character creation or conversion, they have no actual shared origin in lore and thus are treated as separate species.
 
 **Species adapted from other species with no connections in lore are listed as separate entries.** This includes the Flamekin from _Lorwyn: First Light_, which uses the Fire Genasi for its traits but is otherwise narratively unrelated to Genasi. A footnote will list how these adapted species are mechanically connected to their source species.
 

--- a/ch-2-reincarnate.md
+++ b/ch-2-reincarnate.md
@@ -5,62 +5,66 @@ The **Reincarnation Options** table and all subsequent tables below replace the 
 Additionally, the _Reincarnate_ spell can now target any dead creature or piece of one, instead of just Humanoids, as long as its current creature type is represented by any species, ancestry, or variant listed in the tables below. For example, a dead creature with the Fey creature type can be targeted because there are Fey creatures on these tables (such as the fairy or satyr), but a creature with the Beast creature type cannot be targeted because they are not represented on these tables.
 
 ## Reincarnation Options
-| d54 | Species |
+| d58 | Species |
 |:---:|:-|
 | 1 | Aarakocra[^🙈] |
 | 2 | Aasimar (roll on **[Aasimar](#aasimar)** table for ancestry) |
 | 3 | Aetherborn[^🕰️] |
 | 4 | Autognome[^🛸] |
 | 5 | Aven (roll on **[Aven](#aven)** table for ancestry) |
-| 6 | Centaur[^👹] |
-| 7 | Changeling[^👹] |
-| 8 | Dragonborn (roll on **[Dragonborn](#dragonborn)** table for setting) |
-| 9 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
-| 10 | Elf (roll on **[Elves](#elves)** table for setting) |
-| 11 | Fairy[^👹] |
-| 12 | Firbolg[^👹] |
-| 13 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
-| 14 | Giff[^🛸] |
-| 15 | Gith (roll on **[Gith](#gith)** table for ancestry) |
-| 16 | Gnome (roll on **[Gnomes](#gnomes)** table for setting) |
-| 17 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
-| 18 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
-| 19 | Grung[^🐸] |
-| 20 | Hadozee[^🛸] |
-| 21 | Halfling (roll on **[Halflings](#halflings)** table for setting) |
-| 22 | Harengon[^👹] |
-| 23 | Hexblood[^🌫️] |
-| 24 | Human (roll on **[Humans](#humans)** table for setting) |
-| 25 | Kalashtar[^⚙️] |
-| 26 | Kender[^🫅] |
-| 27 | Kenku[^👹] |
-| 28 | Khenra[^☥] |
-| 29 | Kobold[^👹] |
-| 30 | Kor[^🌴] |
-| 31 | Leonin[^🏺] |
-| 32 | Lizardfolk[^👹] |
-| 33 | Locathah[^🐟] |
-| 34 | Loxodon[^🏙️] |
-| 35 | Merfolk (roll on **[Merfolk](#merfolk)** table for setting) |
-| 36 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
-| 37 | Naga[^☥] |
-| 38 | Orc (roll on **[Orcs](#orcs)** table for setting) |
-| 39 | Owlin[^🎓] |
-| 40 | Plasmoid[^🛸] |
-| 41 | Reborn[^🌫️] |
-| 42 | Satyr[^👹] |
-| 43 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
-| 44 | Simic Hybrid[^🏙️] |
-| 45 | Siren[^🦕] |
-| 46 | Tabaxi[^👹] |
-| 47 | Thri-kreen[^🛸] |
-| 48 | Tiefling (roll on **[Tieflings](#tieflings)** table for setting) |
-| 49 | Tortle[^👹] |
-| 50 | Triton[^👹] |
-| 51 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
-| 52 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
-| 53 | Warforged[^⚙️] |
-| 54 | Yuan-ti[^👹] |
+| 6 | Boggart (roll on **[Boggarts](#boggarts)** table for ancestry) |
+| 7 | Centaur[^👹] |
+| 8 | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
+| 9 | Dragonborn (roll on **[Dragonborn](#dragonborn)** table for setting) |
+| 10 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
+| 11 | Elf (roll on **[Elves](#elves)** table for setting) |
+| 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
+| 13 | Firbolg[^👹] |
+| 14 | Flamekin[^🌄][^☄️] |
+| 15 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
+| 16 | Giff[^🛸] |
+| 17 | Gith (roll on **[Gith](#gith)** table for ancestry) |
+| 18 | Gnome (roll on **[Gnomes](#gnomes)** table for setting) |
+| 19 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
+| 20 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
+| 21 | Grung[^🐸] |
+| 22 | Hadozee[^🛸] |
+| 23 | Halfling (roll on **[Halflings](#halflings)** table for setting) |
+| 24 | Harengon[^👹] |
+| 25 | Hexblood[^🌫️] |
+| 26 | Human (roll on **[Humans](#humans)** table for setting) |
+| 27 | Kalashtar[^⚙️] |
+| 28 | Kender[^🫅] |
+| 29 | Kenku[^👹] |
+| 30 | Khenra[^☥] |
+| 31 | Kithkin (roll on **[Kithkin](#kithkin)** table for ancestry) |
+| 32 | Kobold[^👹] |
+| 33 | Kor[^🌴] |
+| 34 | Leonin[^🏺] |
+| 35 | Lizardfolk[^👹] |
+| 36 | Locathah[^🐟] |
+| 37 | Loxodon[^🏙️] |
+| 38 | Merfolk (roll on **[Merfolk](#merfolk)** table for setting) |
+| 39 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
+| 40 | Naga[^☥] |
+| 41 | Orc (roll on **[Orcs](#orcs)** table for setting) |
+| 42 | Owlin[^🎓] |
+| 43 | Plasmoid[^🛸] |
+| 44 | Rimekin[^🌄] |
+| 45 | Reborn[^🌫️] |
+| 46 | Satyr[^👹] |
+| 47 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
+| 48 | Simic Hybrid[^🏙️] |
+| 49 | Siren[^🦕] |
+| 50 | Tabaxi[^👹] |
+| 51 | Thri-kreen[^🛸] |
+| 52 | Tiefling (roll on **[Tieflings](#tieflings)** table for setting) |
+| 53 | Tortle[^👹] |
+| 54 | Triton[^👹] |
+| 55 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
+| 56 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
+| 57 | Warforged[^⚙️] |
+| 58 | Yuan-ti[^👹] |
 
 ### Aasimar
 | d5 | Ancestry |
@@ -76,6 +80,18 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 |:-:|:-|
 | 1 | Hawk-Headed Aven[^☥] |
 | 2 | Ibis-Headed Aven[^☥] |
+
+### Boggarts
+| d2 | Ancestry |
+|:-:|:-|
+| 1 | Lorwyn Boggart[^🌄][^🐒] |
+| 2 | Shadowmoor Boggart[^🌄][^🐒] |
+
+### Changelings
+| d2 | Ancestry |
+|:-:|:-|
+| 1 | Changeling[^👹] |
+| 2 | Lorwyn Changeling[^🌄] |
 
 ### Dragonborn
 | d2 | Setting |
@@ -152,19 +168,20 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 3 | Mountain Dwarf[^🔰1️⃣] |
 
 ### Elves
-| d8 | Setting |
+| d9 | Setting |
 |:-:|:-|
-| 1 | Elf of the Multiverse (roll on **[Elven Lineages](#elven-lineages)** table for ancestry) |
+| 1 | Elf of the Multiverse (roll on **[Elven Lineages](#elven-lineages)** table for lineage) |
 | 2 | Dragonlance Elf (roll on **[Dragonlance Elves](#dragonlance-elves)** table for variant) |
 | 3 | Eberron Elf (roll on **[Eberron Elves](#eberron-elves)** table for variant) |
 | 4 | Exandrian Elf (roll on **[Exandrian Elves](#exandrian-elves)** table for variant) |
 | 5 | Forgotten Realms Elf (roll on **[Forgotten Realms Elves](#forgotten-realms-elves)** table for variant) |
 | 6 | Kaladesh Elf (roll on **[Kaladesh Elves](#kaladesh-elves)** table for variant) |
-| 7 | Ravnica Elf (roll on **[Ravnica Elves](#ravnica-elves)** table for variant) |
-| 8 | Zendikar Elf (roll on **[Zendikar Elves](#zendikar-elves)** table for variant) |
+| 7 | Lorwyn-Shadowmoor Elf (roll on **[Lorwyn-Shadowmoor Elves](#lorwyn-shadowmoor-elves)** table for variant) |
+| 8 | Ravnica Elf (roll on **[Ravnica Elves](#ravnica-elves)** table for variant) |
+| 9 | Zendikar Elf (roll on **[Zendikar Elves](#zendikar-elves)** table for variant) |
 
 #### Elven Lineages
-| d8 | Ancestry |
+| d8 | Lineage |
 |:-:|:-|
 | 1 | Astral Elf[^🛸] |
 | 2 | Drow[^📒2️⃣] |
@@ -228,6 +245,12 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 2 | Tirahar Elf[^🕰️] |
 | 3 | Vahadar Elf[^🕰️] |
 
+#### Lorwyn-Shadowmoor Elves
+| d2 | Lineage |
+|:-:|:-|
+| 1 | Lorwyn Elf[^🌄] |
+| 2 | Shadowmoor Elf[^🌄] |
+
 #### Ravnica Elves
 | d4 | Variant |
 |:-:|:-|
@@ -242,6 +265,18 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 1 | Joraga Nation Elf[^🏹] |
 | 2 | Mul Daya Nation Elf[^🌴] |
 | 3 | Tajuru Nation Elf[^🌴] |
+
+### Fairies
+| d2 | Ancestry |
+|:-:|:-|
+| 1 | Fairy[^👹] |
+| 2 | Lorwyn-Shadowmoor Fairy (roll on **[Lorwyn-Shadowmoor Fairies](#lorwyn-shadowmoor-fairies)** for variant) |
+
+### Lorwyn-Shadowmoor Fairies
+| d2 | Variant |
+|:-:|:-|
+| 1 | Lorwyn Fairy[^🌄][^🧚] |
+| 2 | Shadowmoor Fairy[^🌄][^🧚] |
 
 ### Genasi
 | d4 | Ancestry |
@@ -298,7 +333,7 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | d4 | Setting |
 |:-:|:-|
 | 1 | Goblinoid of the Multiverse (roll on **[Goblinoids of the Multiverse](#goblinoids-of-the-multiverse)** table for variant) |
-| 2 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** for variant) |
+| 2 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** table for variant) |
 | 3 | Ixalan Goblin[^🦕] |
 | 4 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
 
@@ -392,6 +427,12 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 2 | Kessig Human[^🧛] |
 | 3 | Nephalia Human[^🧛] |
 | 4 | Stensia Human[^🧛] |
+
+### Kithkin
+| d2 | Ancestry |
+|:-:|:-|
+| 1 | Lorwyn Kithkin[^🌄][^🥑] |
+| 2 | Shadowmoor Kithkin[^🌄][^🥑] |
 
 ### Merfolk
 | d2 | Setting |
@@ -515,6 +556,7 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 [^🐉]: Source: _Fizban's Treasury of Dragons_
 [^🏙️]: Source: _Guildmasters' Guide to Ravnica_
 [^🐟]: Source: _Locathah Rising_
+[^🌄]: Source: _Lorwyn: First Light_
 [^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
 [^👺]: Source: _Mordenkainen's Tome of Foes_
 [^🏺]: Source: _Mythic Odysseys of Theros_
@@ -537,9 +579,12 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not equivalent to any single prior Aasimar option.
 [^🪓]: The Dwarf was updated in _SRD 5.2_ to remove ancestry selection, and has variants with setting-specific names but no significant mechanical differences from multiverse equivalents. A Dwarf is equivalent to a Hill Dwarf in _SRD 5.1_.
 [^🏹]: The Elf has variants with setting-specific names but no significant mechanical differences from multiverse equivalents. A Moon Elf or Sun Elf is equivalent to a High Elf in _SRD 5.2_, and a Joraga Nation Elf is equivalent to a Wood Elf in _SRD 5.2_.
+[^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
+[^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🍄]: The Gnome has variants with setting-specific names but no significant mechanical differences from multiverse equivalents. A Tinker Gnome is equivalent to a Rock Gnome in _SRD 5.2_.
+[^🐒]: A Lorwyn Boggart and Shadowmoor Boggart in _Lorwyn: First Light_ are mechanically equivalent to a Goblin.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. A Stone Giant Goliath is equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not equivalent to any prior Goliath options.
-[^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection, and has variants with setting-specific names but no significant mechanical differences from multiverse equivalents. A Halfling is equivalent to a Lightfoot Halfling in _SRD 5.1_, and a Strongheart Halfling is equivalent to a Stout Halfling in _Player's Handbook (2014)_.
+[^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection. A Halfling is mechanically equivalent to a Lightfoot Halfling in _SRD 5.1_ and a Lorwyn Kithkin in _Lorwyn: First Light_, and a Strongheart Halfling is mechanically equivalent to a Stout Halfling in _Player's Handbook (2014)_, while a Shadowmoor Kithkin in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Halfling species option.
 [^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_. It is equivalent to a Variant Human in _Player's Handbook (2014)_.
 [^🍖]: The Orc replaced the Half-Orc option from _SRD 5.1_. An Ixalan Orc is equivalent to a Half-Orc.
 [^🌙]: The Shifter was updated in _Mordenkainen's Monsters of the Multiverse_ to remove ancestry selection. The updated Shifter is not equivalent to any single prior Shifter option.

--- a/ch-2-reincarnate.md
+++ b/ch-2-reincarnate.md
@@ -5,66 +5,65 @@ The **Reincarnation Options** table and all subsequent tables below replace the 
 Additionally, the _Reincarnate_ spell can now target any dead creature or piece of one, instead of just Humanoids, as long as its current creature type is represented by any species, ancestry, or variant listed in the tables below. For example, a dead creature with the Fey creature type can be targeted because there are Fey creatures on these tables (such as the fairy or satyr), but a creature with the Beast creature type cannot be targeted because they are not represented on these tables.
 
 ## Reincarnation Options
-| d58 | Species |
+| d57 | Species |
 |:---:|:-|
 | 1 | Aarakocra[^🙈] |
 | 2 | Aasimar (roll on **[Aasimar](#aasimar)** table for ancestry) |
 | 3 | Aetherborn[^🕰️] |
 | 4 | Autognome[^🛸] |
 | 5 | Aven (roll on **[Aven](#aven)** table for ancestry) |
-| 6 | Boggart (roll on **[Boggarts](#boggarts)** table for ancestry) |
-| 7 | Centaur[^👹] |
-| 8 | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
-| 9 | Dragonborn (roll on **[Dragonborn](#dragonborn)** table for setting) |
-| 10 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
-| 11 | Elf (roll on **[Elves](#elves)** table for setting) |
-| 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
-| 13 | Firbolg[^👹] |
-| 14 | Flamekin[^🌄][^☄️] |
-| 15 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
-| 16 | Giff[^🛸] |
-| 17 | Gith (roll on **[Gith](#gith)** table for ancestry) |
-| 18 | Gnome (roll on **[Gnomes](#gnomes)** table for setting) |
-| 19 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
-| 20 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
-| 21 | Grung[^🐸] |
-| 22 | Hadozee[^🛸] |
-| 23 | Halfling (roll on **[Halflings](#halflings)** table for setting) |
-| 24 | Harengon[^👹] |
-| 25 | Hexblood[^🌫️] |
-| 26 | Human (roll on **[Humans](#humans)** table for setting) |
-| 27 | Kalashtar[^⚙️] |
-| 28 | Kender[^🫅] |
-| 29 | Kenku[^👹] |
-| 30 | Khenra[^☥] |
-| 31 | Kithkin (roll on **[Kithkin](#kithkin)** table for ancestry) |
-| 32 | Kobold[^👹] |
-| 33 | Kor[^🌴] |
-| 34 | Leonin[^🏺] |
-| 35 | Lizardfolk[^👹] |
-| 36 | Locathah[^🐟] |
-| 37 | Loxodon[^🏙️] |
-| 38 | Merfolk (roll on **[Merfolk](#merfolk)** table for setting) |
-| 39 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
-| 40 | Naga[^☥] |
-| 41 | Orc (roll on **[Orcs](#orcs)** table for setting) |
-| 42 | Owlin[^🎓] |
-| 43 | Plasmoid[^🛸] |
-| 44 | Rimekin[^🌄] |
-| 45 | Reborn[^🌫️] |
-| 46 | Satyr[^👹] |
-| 47 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
-| 48 | Simic Hybrid[^🏙️] |
-| 49 | Siren[^🦕] |
-| 50 | Tabaxi[^👹] |
-| 51 | Thri-kreen[^🛸] |
-| 52 | Tiefling (roll on **[Tieflings](#tieflings)** table for setting) |
-| 53 | Tortle[^👹] |
-| 54 | Triton[^👹] |
-| 55 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
-| 56 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
-| 57 | Warforged[^⚙️] |
-| 58 | Yuan-ti[^👹] |
+| 6 | Centaur[^👹] |
+| 7 | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
+| 8 | Dragonborn (roll on **[Dragonborn](#dragonborn)** table for setting) |
+| 9 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
+| 10 | Elf (roll on **[Elves](#elves)** table for setting) |
+| 11 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
+| 12 | Firbolg[^👹] |
+| 13 | Flamekin[^🌄][^☄️] |
+| 14 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
+| 15 | Giff[^🛸] |
+| 16 | Gith (roll on **[Gith](#gith)** table for ancestry) |
+| 17 | Gnome (roll on **[Gnomes](#gnomes)** table for setting) |
+| 18 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
+| 19 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
+| 20 | Grung[^🐸] |
+| 21 | Hadozee[^🛸] |
+| 22 | Halfling (roll on **[Halflings](#halflings)** table for setting) |
+| 23 | Harengon[^👹] |
+| 24 | Hexblood[^🌫️] |
+| 25 | Human (roll on **[Humans](#humans)** table for setting) |
+| 26 | Kalashtar[^⚙️] |
+| 27 | Kender[^🫅] |
+| 28 | Kenku[^👹] |
+| 29 | Khenra[^☥] |
+| 30 | Kithkin (roll on **[Kithkin](#kithkin)** table for ancestry) |
+| 31 | Kobold[^👹] |
+| 32 | Kor[^🌴] |
+| 33 | Leonin[^🏺] |
+| 34 | Lizardfolk[^👹] |
+| 35 | Locathah[^🐟] |
+| 36 | Loxodon[^🏙️] |
+| 37 | Merfolk (roll on **[Merfolk](#merfolk)** table for setting) |
+| 38 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
+| 39 | Naga[^☥] |
+| 40 | Orc (roll on **[Orcs](#orcs)** table for setting) |
+| 41 | Owlin[^🎓] |
+| 42 | Plasmoid[^🛸] |
+| 43 | Rimekin[^🌄] |
+| 44 | Reborn[^🌫️] |
+| 45 | Satyr[^👹] |
+| 46 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
+| 47 | Simic Hybrid[^🏙️] |
+| 48 | Siren[^🦕] |
+| 49 | Tabaxi[^👹] |
+| 50 | Thri-kreen[^🛸] |
+| 51 | Tiefling (roll on **[Tieflings](#tieflings)** table for setting) |
+| 52 | Tortle[^👹] |
+| 53 | Triton[^👹] |
+| 54 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
+| 55 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
+| 56 | Warforged[^⚙️] |
+| 57 | Yuan-ti[^👹] |
 
 ### Aasimar
 | d5 | Ancestry |
@@ -80,12 +79,6 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 |:-:|:-|
 | 1 | Hawk-Headed Aven[^☥] |
 | 2 | Ibis-Headed Aven[^☥] |
-
-### Boggarts
-| d2 | Ancestry |
-|:-:|:-|
-| 1 | Lorwyn Boggart[^🌄][^🐒] |
-| 2 | Shadowmoor Boggart[^🌄][^🐒] |
 
 ### Changelings
 | d2 | Ancestry |
@@ -330,12 +323,13 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 3 | Rock Gnome[^📒2️⃣] |
 
 ### Goblinoids
-| d4 | Setting |
+| d5 | Setting |
 |:-:|:-|
 | 1 | Goblinoid of the Multiverse (roll on **[Goblinoids of the Multiverse](#goblinoids-of-the-multiverse)** table for variant) |
-| 2 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** table for variant) |
-| 3 | Ixalan Goblin[^🦕] |
-| 4 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
+| 2 | Boggart (roll on **[Boggarts](#boggarts)** table for variant) |
+| 3 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** table for variant) |
+| 4 | Ixalan Goblin[^🦕] |
+| 5 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
 
 #### Goblinoids of the Multiverse
 | d3 | Variant |
@@ -343,6 +337,12 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 | 1 | Bugbear[^👹] |
 | 2 | Goblin[^👹] |
 | 3 | Hobgoblin[^👹] |
+
+#### Boggarts
+| d2 | Variant |
+|:-:|:-|
+| 1 | Lorwyn Boggart[^🌄][^🐒] |
+| 2 | Shadowmoor Boggart[^🌄][^🐒] |
 
 #### Forgotten Realms Goblinoids
 | d4 | Variant |
@@ -582,7 +582,7 @@ Additionally, the _Reincarnate_ spell can now target any dead creature or piece 
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🍄]: The Gnome has variants with setting-specific names but no significant mechanical differences from multiverse equivalents. A Tinker Gnome is equivalent to a Rock Gnome in _SRD 5.2_.
-[^🐒]: A Lorwyn Boggart and Shadowmoor Boggart in _Lorwyn: First Light_ are mechanically equivalent to a Goblin.
+[^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. A Stone Giant Goliath is equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not equivalent to any prior Goliath options.
 [^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection. A Halfling is mechanically equivalent to a Lightfoot Halfling in _SRD 5.1_ and a Lorwyn Kithkin in _Lorwyn: First Light_, and a Strongheart Halfling is mechanically equivalent to a Stout Halfling in _Player's Handbook (2014)_, while a Shadowmoor Kithkin in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Halfling species option.
 [^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_. It is equivalent to a Variant Human in _Player's Handbook (2014)_.

--- a/ch-2-reincarnate.md
+++ b/ch-2-reincarnate.md
@@ -2,7 +2,7 @@
 
 Replace the _Reincarnate_ spell's description with the following text and tables:
 
-You touch a dead creature or a piece of one. If the creature has been dead no longer than 10 days, the spell forms a new body for it and calls the soul to enter that body. Roll 1d54 and consult the **Reincarnation Options** table and all subsequent tables to determine the body's species, or the GM chooses another playable species. The dead creature or piece of one can be any creature type represented by a species, ancestry, or variant in any of the tables below: **Construct**, **Fey**, **Humanoid**, **Monstrosity**, or **Ooze**. For example, a dead creature with the Fey creature type can be targeted because there are Fey species on these tables, such as the Fairy or Satyr, but a dead creature with the Beast creature type cannot be targeted because they are not represented on these tables.
+You touch a dead creature or a piece of one. If the creature has been dead no longer than 10 days, the spell forms a new body for it and calls the soul to enter that body. Roll 1d57 and consult the **Reincarnation Options** table and all subsequent tables to determine the body's species, or the GM chooses another playable species. The dead creature or piece of one can be any creature type represented by a species, ancestry, or variant in any of the tables below: **Construct**, **Fey**, **Humanoid**, **Monstrosity**, or **Ooze**. For example, a dead creature with the Fey creature type can be targeted because there are Fey species on these tables, such as the Fairy or Satyr, but a dead creature with the Beast creature type cannot be targeted because they are not represented on these tables.
 
 ## Reincarnation Options
 | d57 | Species |


### PR DESCRIPTION
- Reincarnate:
  - added species options from _Lorwyn: First Light_: Lorwyn Boggart, Shadowmoor Boggart, Lorwyn Changeling, Lorwyn Elf, Shadowmoor Elf, Lorwyn Fairy, Shadowmoor Fairy, Lorwyn Kithkin, Shadowmoor Kithkin, Flamekin, and Rimekin
  - added tables for new species options:
    - Boggarts (part of Goblinoid species)
    - Changelings (multiverse vs Lorwyn)
    - Lorwyn-Shadowmoor Elves
    - Fairies (multiverse vs Lorwyn-Shadowmoor)
    - Lorwyn-Shadowmoor Fairies
    - Kithkin
- added footnotes for associating adapted species
- Thesis:
  - called out creature type options in How to Use These Tables
  - divided Grouping and Separating assumptions
    - rewrote Dhampir/Vampire grouping assumption
    - noted Adapted Species organizational choices (separate entries when unrelated to source species)
- added _Lorwyn: First Light_ to Third-Party Content References