### PR TITLE
split multi-table species into dedicated pages

### DIFF
--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -29,7 +29,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 8  | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
 | 9  | Dragonborn (roll on **[Dragonborn](dragonborn.md)** table for setting) |
 | 10 | Dwarf (roll on **[Dwarves](dwarves.md)** table for setting) |
-| 11 | Elf (roll on **[Elves](#elves)** table for setting) |
+| 11 | Elf (roll on **[Elves](elves.md)** table for setting) |
 | 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
 | 13 | Firbolg[^👹] |
 | 14 | Flamekin[^🌄][^☄️] |
@@ -98,105 +98,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Changeling[^👹] |
 | 2 | Lorwyn Changeling[^🌄] |
-
-#### Elves
-| d9 | Setting |
-|:-:|:-|
-| 1 | Elf of the Multiverse (roll on **[Elven Lineages](#elven-lineages)** table for lineage) |
-| 2 | Dragonlance Elf (roll on **[Dragonlance Elves](#dragonlance-elves)** table for variant) |
-| 3 | Eberron Elf (roll on **[Eberron Elves](#eberron-elves)** table for variant) |
-| 4 | Exandrian Elf (roll on **[Exandrian Elves](#exandrian-elves)** table for variant) |
-| 5 | Forgotten Realms Elf (roll on **[Forgotten Realms Elves](#forgotten-realms-elves)** table for variant) |
-| 6 | Kaladesh Elf (roll on **[Kaladesh Elves](#kaladesh-elves)** table for variant) |
-| 7 | Lorwyn-Shadowmoor Elf (roll on **[Lorwyn-Shadowmoor Elves](#lorwyn-shadowmoor-elves)** table for variant) |
-| 8 | Ravnica Elf (roll on **[Ravnica Elves](#ravnica-elves)** table for variant) |
-| 9 | Zendikar Elf (roll on **[Zendikar Elves](#zendikar-elves)** table for variant) |
-
-##### Elven Lineages
-| d8 | Lineage |
-|:-:|:-|
-| 1 | Astral Elf[^🛸] |
-| 2 | Drow[^📒2️⃣] |
-| 3 | Eladrin[^👹] |
-| 4 | Half-Elf[^📒1️⃣] |
-| 5 | High Elf[^📒2️⃣] |
-| 6 | Sea Elf[^👹] |
-| 7 | Shadar-kai[^👹] |
-| 8 | Wood Elf[^📒2️⃣] |
-
-##### Dragonlance Elves
-| d3 | Variant |
-|:-:|:-|
-| 1 | High Elf[^🏹] |
-| 2 | Sea Elf[^👹] |
-| 3 | Wood Elf[^🏹] |
-
-##### Eberron Elves
-| d11 | Variant |
-|:-:|:-|
-| 1 | Aereni High Elf[^🧭] |
-| 2 | Aereni Wood Elf[^🧭] |
-| 3 | Drow[^📒2️⃣] |
-| 4 | Half-Elf[^📒1️⃣] |
-| 5 | High Elf[^📒2️⃣] |
-| 6 | Mark of Detection Half-Elf[^⚙️] |
-| 7 | Mark of Shadow Elf[^⚙️] |
-| 8 | Mark of Storm Half-Elf[^⚙️] |
-| 9 | Valenar High Elf[^🧭] |
-| 10 | Valenar Wood Elf[^🧭] |
-| 11 | Wood Elf[^📒2️⃣] |
-
-##### Exandrian Elves
-| d6 | Variant |
-|:-:|:-|
-| 1 | Drow[^📒2️⃣] |
-| 2 | Half-Elf[^📒1️⃣] |
-| 3 | High Elf[^📒2️⃣] |
-| 4 | Pallid Elf[^⏳] |
-| 5 | Sea Elf[^👹] |
-| 6 | Wood Elf[^📒2️⃣] |
-
-##### Forgotten Realms Elves
-| d10 | Variant |
-|:-:|:-|
-| 1 | Aquatic Half-Elf[^🗡️] |
-| 2 | Drow[^📒2️⃣] |
-| 3 | Drow Half-Elf[^🗡️] |
-| 4 | Half-Elf[^📒1️⃣] |
-| 5 | Moon Elf[^📒2️⃣][^🏹] |
-| 6 | Moon Half-Elf[^🗡️] |
-| 7 | Sun Elf[^📒2️⃣][^🏹] |
-| 8 | Sun Half-Elf[^🗡️] |
-| 9 | Wood Elf[^📒2️⃣] |
-| 10 | Wood Half-Elf[^🗡️] |
-
-##### Kaladesh Elves
-| d3 | Variant |
-|:-:|:-|
-| 1 | Bishtahar Elf[^🕰️] |
-| 2 | Tirahar Elf[^🕰️] |
-| 3 | Vahadar Elf[^🕰️] |
-
-##### Lorwyn-Shadowmoor Elves
-| d2 | Lineage |
-|:-:|:-|
-| 1 | Lorwyn Elf[^🌄] |
-| 2 | Shadowmoor Elf[^🌄] |
-
-##### Ravnica Elves
-| d4 | Variant |
-|:-:|:-|
-| 1 | Drow[^📒2️⃣] |
-| 2 | Half-Elf[^📒1️⃣] |
-| 3 | High Elf[^📒2️⃣] |
-| 4 | Wood Elf[^📒2️⃣] |
-
-##### Zendikar Elves
-| d3 | Variant |
-|:-:|:-|
-| 1 | Joraga Nation Elf[^🏹] |
-| 2 | Mul Daya Nation Elf[^🌴] |
-| 3 | Tajuru Nation Elf[^🌴] |
 
 #### Fairies
 | d2 | Ancestry |
@@ -514,10 +415,8 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^📒1️⃣]: Source: _SRD 5.1_
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🌫️]: Source: _Van Richten's Guide to Ravenloft_
-[^🧭]: Source: _Wayfinder's Guide to Eberron_
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not mechanically equivalent to any single prior Aasimar option.
 [^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms are mechanically equivalent to a High Elf in _SRD 5.2_, and the Joraga Nation Elf of Zendikar is mechanically equivalent to a Wood Elf in _SRD 5.2_.
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_, and the Deep Gnome is mechanically equivalent to a Svirfneblin in _Elemental Evil Player's Companion_.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -27,8 +27,8 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 6  | Aven (roll on **[Aven](#aven)** table for ancestry) |
 | 7  | Centaur[^👹] |
 | 8  | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
-| 9  | Dragonborn (roll on **[Dragonborn](#dragonborn)** table for setting) |
-| 10  | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
+| 9  | Dragonborn (roll on **[Dragonborn](dragonborn.md)** table for setting) |
+| 10 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
 | 11 | Elf (roll on **[Elves](#elves)** table for setting) |
 | 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
 | 13 | Firbolg[^👹] |
@@ -98,52 +98,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Changeling[^👹] |
 | 2 | Lorwyn Changeling[^🌄] |
-
-#### Dragonborn
-| d2 | Setting |
-|:-:|:-|
-| 1 | Dragonborn of the Multiverse (roll on **[Draconic Ancestor](#draconic-ancestor)** table for ancestry) |
-| 2 | Exandrian Dragonborn (roll on **[Exandrian Dragonborn](#exandrian-dragonborn)** table for variant) |
-
-##### Draconic Ancestor
-| d3 | Ancestry |
-|:-:|:-|
-| 1 | Chromatic Dragonborn (roll on **[Chromatic Dragonborn](#chromatic-dragonborn)** table for color) |
-| 2 | Gem Dragonborn (roll on **[Gem Dragonborn](#gem-dragonborn)** table for gemstone) |
-| 3 | Metallic Dragonborn (roll on **[Metallic Dragonborn](#metallic-dragonborn)** table for metal) |
-
-###### Chromatic Dragonborn
-| d5 | Color |
-|:-:|:-|
-| 1 | Black[^📒2️⃣] |
-| 2 | Blue[^📒2️⃣] |
-| 3 | Green[^📒2️⃣] |
-| 4 | Red[^📒2️⃣] |
-| 5 | White[^📒2️⃣] |
-
-###### Gem Dragonborn
-| d5 | Gemstone |
-|:-:|:-|
-| 1 | Amethyst[^🐉] |
-| 2 | Crystal[^🐉]|
-| 3 | Emerald[^🐉] |
-| 4 | Sapphire[^🐉] |
-| 5 | Topaz[^🐉] |
-
-###### Metallic Dragonborn
-| d5 | Metal |
-|:-:|:-|
-| 1 | Brass[^📒2️⃣] |
-| 2 | Bronze[^📒2️⃣] |
-| 3 | Copper[^📒2️⃣] |
-| 4 | Gold[^📒2️⃣] |
-| 5 | Silver[^📒2️⃣] |
-
-##### Exandrian Dragonborn
-| d2 | Variant |
-|:-:|:-|
-| 1 | Draconblood Dragonborn[^⏳] |
-| 2 | Ravenite Dragonborn[^⏳] |
 
 #### Dwarves
 | d5 | Setting |
@@ -575,7 +529,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^⚙️]: Source: _Eberron: Rising from the Last War_
 [^🙈]: Source: _Elemental Evil Player's Companion_
 [^⏳]: Source: _Explorer's Guide to Wildemount_
-[^🐉]: Source: _Fizban's Treasury of Dragons_
 [^🏙️]: Source: _Guildmasters' Guide to Ravnica_
 [^🐟]: Source: _Locathah Rising_
 [^🌄]: Source: _Lorwyn: First Light_

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -41,7 +41,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 20 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
 | 21 | Grung[^🐸] |
 | 22 | Hadozee[^🛸] |
-| 23 | Halfling (roll on **[Halflings](#halflings)** table for setting) |
+| 23 | Halfling (roll on **[Halflings](halflings.md)** table for setting) |
 | 24 | Harengon[^👹] |
 | 25 | Hexblood[^🌫️] |
 | 26 | Human (roll on **[Humans](#humans)** table for setting) |
@@ -134,42 +134,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Githyanki[^👹] |
 | 2 | Githzerai[^👹] |
-
-#### Halflings
-| d4 | Setting |
-|:-:|:-|
-| 1 | Halfling of the Multiverse (roll on **[Halflings of the Multiverse](#halflings-of-the-multiverse)** table for variant) |
-| 2 | Eberron Halfling (roll on **[Eberron Halflings](#eberron-halflings)** table for variant) |
-| 3 | Exandrian Halfling (roll on **[Exandrian Halflings](#exandrian-halflings)** table for variant) |
-| 4 | Forgotten Realms Halfling (roll on **[Forgotten Realms Halflings](#forgotten-realms-halflings)** for variant) |
-
-##### Halflings of the Multiverse
-| d2 | Variant |
-|:-:|:-|
-| 1 | Halfling[^📒2️⃣][^🥑] |
-| 2 | Stout Halfling[^🔰1️⃣] |
-
-##### Eberron Halflings
-| d4 | Variant |
-|:-:|:-|
-| 1 | Lightfoot Halfling[^📒2️⃣][^🥑] |
-| 2 | Mark of Healing Halfling[^⚙️] |
-| 3 | Mark of Hospitality Halfling[^⚙️] |
-| 4 | Stout Halfling[^🔰1️⃣] |
-
-##### Exandrian Halflings
-| d3 | Variant |
-|:-:|:-|
-| 1 | Halfling[^📒2️⃣][^🥑] |
-| 2 | Lotusden Halfling[^⏳] |
-| 3 | Stout Halfling[^🔰1️⃣] |
-
-##### Forgotten Realms Halflings
-| d3 | Variant |
-|:-:|:-|
-| 1 | Lightfoot Halfling[^📒2️⃣][^🥑] |
-| 2 | Ghostwise Halfling[^🗡️] |
-| 3 | Strongheart Halfling[^🔰1️⃣][^🥑] |
 
 #### Humans
 | d5 | Setting |
@@ -328,7 +292,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🦹]: Source: _Dungeon Master's Guide (2014)_
 [^⚙️]: Source: _Eberron: Rising from the Last War_
 [^🙈]: Source: _Elemental Evil Player's Companion_
-[^⏳]: Source: _Explorer's Guide to Wildemount_
 [^🏙️]: Source: _Guildmasters' Guide to Ravnica_
 [^🐟]: Source: _Locathah Rising_
 [^🌄]: Source: _Lorwyn: First Light_
@@ -342,7 +305,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🦕]: Source: _Plane Shift: Ixalan_
 [^🕰️]: Source: _Plane Shift: Kaladesh_
 [^🌴]: Source: _Plane Shift: Zendikar_
-[^🔰1️⃣]: Source: _Player's Handbook (2014)_
 [^🔰2️⃣]: Source: _Player's Handbook (2024)_
 [^🛸]: Source: _Spelljammer: Adventures in Space_
 [^🎓]: Source: _Strixhaven: Curriculum of Chaos_
@@ -354,7 +316,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
-[^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection. The Halfling is mechanically equivalent to a Lightfoot Halfling in _SRD 5.1_ and a Lorwyn Kithkin, a Strongheart Halfling of the Forgotten Realms can be represented either with a Halfling in _SRD 5.2_ or a Stout Halfling in _Player's Handbook (2014)_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
+[^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halfling.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
 [^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_, which this document labels as "Human (2014)" to distinguish the option. It is mechanically equivalent to a Variant Human in _Player's Handbook (2014)_.
 [^🍖]: The Orc replaced the Half-Orc option from _SRD 5.1_. The Ixalan Orc is mechanically equivalent to a Half-Orc.
 [^😈]: The Tiefling was updated in _SRD 5.2_ to provide a Fiendish Legacies option. The Infernal Tiefling is mechanically equivalent to a Tiefling in _SRD 5.1_ or an Asmodeus Tiefling in _Mordenkainen's Tome of Foes_. The other ancestries are not mechanically equivalent to any prior Tiefling options, but the Abyssal Tiefling shares some spells with the Baalzebul Tiefling in _Mordenkainen's Tome of Foes_ (see the **[Infernal Tieflings](#infernal-tieflings)**[^👿] table).

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -44,7 +44,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 23 | Halfling (roll on **[Halflings](halflings.md)** table for setting) |
 | 24 | Harengon[^👹] |
 | 25 | Hexblood[^🌫️] |
-| 26 | Human (roll on **[Humans](#humans)** table for setting) |
+| 26 | Human (roll on **[Humans](humans.md)** table for setting) |
 | 27 | Kalashtar[^⚙️] |
 | 28 | Kender[^🫅] |
 | 29 | Kenku[^👹] |
@@ -134,39 +134,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Githyanki[^👹] |
 | 2 | Githzerai[^👹] |
-
-#### Humans
-| d5 | Setting |
-|:-:|:-|
-| 1 | Human of the Multiverse (roll on **[Humans of the Multiverse](#humans-of-the-multiverse)** table for variant) |
-| 2 | Eberron Human (roll on **[Eberron Humans](#eberron-humans)** table for variant) |
-| 3 | Innistrad Human (roll on **[Innistrad Provinces](#innistrad-provinces)** table for provincial origin) |
-| 4 | Keldon Human[^🛡️] |
-
-##### Humans of the Multiverse
-| d2 | Variant |
-|:-:|:-|
-| 1 | Human[^📒2️⃣][^👤] |
-| 2 | Human (2014)[^📒1️⃣] |
-
-##### Eberron Humans
-| d7 | Variant |
-|:-:|:-|
-| 1 | Human[^📒2️⃣][^👤] |
-| 2 | Human (2014)[^📒1️⃣] |
-| 3 | Mark of Finding Human[^⚙️] |
-| 4 | Mark of Handling Human[^⚙️] |
-| 5 | Mark of Making Human[^⚙️] |
-| 6 | Mark of Passage Human[^⚙️] |
-| 7 | Mark of Sentinel Human[^⚙️] |
-
-##### Innistrad Provinces
-| d4 | Provincial Origin |
-|:-:|:-|
-| 1 | Gavony Human[^🧛] |
-| 2 | Kessig Human[^🧛] |
-| 3 | Nephalia Human[^🧛] |
-| 4 | Stensia Human[^🧛] |
 
 #### Kithkin
 | d2 | Ancestry |
@@ -300,8 +267,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🏺]: Source: _Mythic Odysseys of Theros_
 [^🐸]: Source: _One Grung Above_
 [^☥]: Source: _Plane Shift: Amonkhet_
-[^🛡️]: Source: _Plane Shift: Dominaria_
-[^🧛]: Source: _Plane Shift: Innistrad_
 [^🦕]: Source: _Plane Shift: Ixalan_
 [^🕰️]: Source: _Plane Shift: Kaladesh_
 [^🌴]: Source: _Plane Shift: Zendikar_
@@ -317,7 +282,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halfling.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
-[^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_, which this document labels as "Human (2014)" to distinguish the option. It is mechanically equivalent to a Variant Human in _Player's Handbook (2014)_.
 [^🍖]: The Orc replaced the Half-Orc option from _SRD 5.1_. The Ixalan Orc is mechanically equivalent to a Half-Orc.
 [^😈]: The Tiefling was updated in _SRD 5.2_ to provide a Fiendish Legacies option. The Infernal Tiefling is mechanically equivalent to a Tiefling in _SRD 5.1_ or an Asmodeus Tiefling in _Mordenkainen's Tome of Foes_. The other ancestries are not mechanically equivalent to any prior Tiefling options, but the Abyssal Tiefling shares some spells with the Baalzebul Tiefling in _Mordenkainen's Tome of Foes_ (see the **[Infernal Tieflings](#infernal-tieflings)**[^👿] table).
 [^👿]: These classifications of Tiefling variants were added in _Mordenkainen's Tome of Foes_ to describe Tieflings with special links to one of the Lords of the Nine Hells, and they have thus been grouped together as variant Infernal Tieflings. The Asmodeus Tiefling is mechanically equivalent to an Infernal Tiefling in _SRD 5.2_. The other ancestries are not mechanically equivalent to any other Tiefling options, but the Baalzebul Tiefling shares some spells with the Abyssal Tiefling in _SRD 5.2_.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -36,7 +36,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 15 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
 | 16 | Giff[^🛸] |
 | 17 | Gith (roll on **[Gith](#gith)** table for ancestry) |
-| 18 | Gnome (roll on **[Gnomes](#gnomes)** table for setting) |
+| 18 | Gnome (roll on **[Gnomes](gnomes.md)** table for setting) |
 | 19 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
 | 20 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
 | 21 | Grung[^🐸] |
@@ -134,33 +134,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Githyanki[^👹] |
 | 2 | Githzerai[^👹] |
-
-#### Gnomes
-| d3 | Setting |
-|:-:|:-|
-| 1 | Gnome of the Multiverse (roll on **[Gnomish Lineages](#gnomish-lineages)** table for ancestry) |
-| 2 | Dragonlance Gnome (roll on **[Dragonlance Gnomes](#dragonlance-gnomes)** table for variant) |
-| 3 | Eberron Gnome (roll on **[Eberron Gnomes](#eberron-gnomes)** table for variant) |
-
-##### Gnomish Lineages
-| d3 | Ancestry |
-|:-:|:-|
-| 1 | Deep Gnome[^🙈][^🍄] |
-| 2 | Forest Gnome[^📒2️⃣] |
-| 3 | Rock Gnome[^📒2️⃣] |
-
-##### Dragonlance Gnomes
-| d2 | Variant |
-|:-:|:-|
-| 1 | Forest Gnome[^📒2️⃣] |
-| 2 | Tinker Gnome[^🍄] |
-
-##### Eberron Gnome
-| d3 | Variant |
-|:-:|:-|
-| 1 | Forest Gnome[^📒2️⃣] |
-| 2 | Mark of Scribing Gnome[^⚙️] |
-| 3 | Rock Gnome[^📒2️⃣] |
 
 #### Goblinoids
 | d5 | Setting |
@@ -419,7 +392,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
-[^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_, and the Deep Gnome is mechanically equivalent to a Svirfneblin in _Elemental Evil Player's Companion_.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection. The Halfling is mechanically equivalent to a Lightfoot Halfling in _SRD 5.1_ and a Lorwyn Kithkin, a Strongheart Halfling of the Forgotten Realms can be represented either with a Halfling in _SRD 5.2_ or a Stout Halfling in _Player's Handbook (2014)_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
 [^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_, which this document labels as "Human (2014)" to distinguish the option. It is mechanically equivalent to a Variant Human in _Player's Handbook (2014)_.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -59,7 +59,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 38 | Merfolk (roll on **[Merfolk](merfolk.md)** table for setting) |
 | 39 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
 | 40 | Naga[^☥] |
-| 41 | Orc (roll on **[Orcs](#orcs)** table for setting) |
+| 41 | Orc (roll on **[Orcs](orcs.md)** table for setting) |
 | 42 | Owlin[^🎓] |
 | 43 | Plasmoid[^🛸] |
 | 44 | Rimekin[^🌄] |
@@ -134,26 +134,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Minotaur[^👹] |
 | 2 | Amonkhet Minotaur[^☥] |
-
-#### Orcs
-| d2 | Setting |
-|:-:|:-|
-| 1 | Orc of the Multiverse (roll on **[Orcs of the Multiverse](#orcs-of-the-multiverse)** table for variant) |
-| 2 | Eberron Orc (roll on **[Eberron Orcs](#eberron-orcs)** table for variant) |
-| 3 | Ixalan Orc[^🍖] |
-
-##### Orcs of the Multiverse
-| d2 | Variant |
-|:-:|:-|
-| 1 | Orc[^📒2️⃣] |
-| 2 | Half-Orc[^📒1️⃣] |
-
-##### Eberron Orcs
-| d3 | Variant |
-|:-:|:-|
-| 1 | Half-Orc[^📒1️⃣] |
-| 2 | Mark of Finding Half-Orc[^⚙️] |
-| 3 | Orc[^📒2️⃣] |
 
 #### Shifters
 | d4 | Ancestry |
@@ -250,6 +230,5 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halfling.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
-[^🍖]: The Orc replaced the Half-Orc option from _SRD 5.1_. The Ixalan Orc is mechanically equivalent to a Half-Orc.
 [^😈]: The Tiefling was updated in _SRD 5.2_ to provide a Fiendish Legacies option. The Infernal Tiefling is mechanically equivalent to a Tiefling in _SRD 5.1_ or an Asmodeus Tiefling in _Mordenkainen's Tome of Foes_. The other ancestries are not mechanically equivalent to any prior Tiefling options, but the Abyssal Tiefling shares some spells with the Baalzebul Tiefling in _Mordenkainen's Tome of Foes_ (see the **[Infernal Tieflings](#infernal-tieflings)**[^👿] table).
 [^👿]: These classifications of Tiefling variants were added in _Mordenkainen's Tome of Foes_ to describe Tieflings with special links to one of the Lords of the Nine Hells, and they have thus been grouped together as variant Infernal Tieflings. The Asmodeus Tiefling is mechanically equivalent to an Infernal Tiefling in _SRD 5.2_. The other ancestries are not mechanically equivalent to any other Tiefling options, but the Baalzebul Tiefling shares some spells with the Abyssal Tiefling in _SRD 5.2_.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -70,7 +70,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 49 | Siren[^🦕] |
 | 50 | Tabaxi[^👹] |
 | 51 | Thri-kreen[^🛸] |
-| 52 | Tiefling (roll on **[Tieflings](#tieflings)** table for setting) |
+| 52 | Tiefling (roll on **[Tieflings](tieflings.md)** table for setting) |
 | 53 | Tortle[^👹] |
 | 54 | Triton[^👹] |
 | 55 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
@@ -143,47 +143,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 3 | Swiftstride Shifter[^👹] |
 | 4 | Wildhunt Shifter[^👹] |
 
-#### Tieflings
-| d2 | Setting |
-|:--:|:-|
-| 1 | Tiefling of the Multiverse (roll on **[Fiendish Legacies](#fiendish-legacies)**[^😈] table for ancestry) |
-| 2 | Forgotten Realms Tiefling (roll on **[Forgotten Realms Tieflings](#forgotten-realms-tieflings)** table for variant) |
-
-##### Fiendish Legacies
-| d3 | Ancestry |
-|:--:|:-|
-| 1 | Abyssal Tiefling[^📒2️⃣] |
-| 2 | Chthonic Tiefling[^📒2️⃣] |
-| 3 | Infernal Tiefling (roll on **[Infernal Tieflings](#infernal-tieflings)**[^👿] table for variant) |
-
-###### Infernal Tieflings
-| d9 | Variant |
-|:--:|:-|
-| 1 | Asmodeus Tiefling[^😈] |
-| 2 | Baalzebul Tiefling[^👺] |
-| 3 | Dispater Tiefling[^👺] |
-| 4 | Fierna Tiefling[^👺] |
-| 5 | Glasya Tiefling[^👺] |
-| 6 | Levistus Tiefling[^👺] |
-| 7 | Mammon Tiefling[^👺] |
-| 8 | Mephistopheles Tiefling[^👺] |
-| 9 | Zariel Tiefling[^👺] |
-
-##### Forgotten Realms Tieflings
-| d4 | Variant |
-|:-:|:-|
-| 1 | Abyssal Tiefling[^📒2️⃣] |
-| 2 | Chthonic Tiefling[^📒2️⃣] |
-| 3 | Infernal Tiefling (roll on **[Infernal Tieflings](#infernal-tieflings)**[^👿] table for variant) |
-| 4 | Feral Tiefling (roll on **[Feral Tieflings](#feral-tieflings)** table for variant) |
-
-###### Feral Tieflings
-| d3 | Variant |
-|:-:|:-|
-| 1 | Devil's Tongue Feral Tiefling[^🗡️] |
-| 2 | Hellfire Feral Tiefling[^🗡️] |
-| 3 | Winged Feral Tiefling[^🗡️] |
-
 #### Vampires
 | d3 | Ancestry |
 |:-:|:-|
@@ -212,7 +171,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🐟]: Source: _Locathah Rising_
 [^🌄]: Source: _Lorwyn: First Light_
 [^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
-[^👺]: Source: _Mordenkainen's Tome of Foes_
 [^🏺]: Source: _Mythic Odysseys of Theros_
 [^🐸]: Source: _One Grung Above_
 [^☥]: Source: _Plane Shift: Amonkhet_
@@ -222,7 +180,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🔰2️⃣]: Source: _Player's Handbook (2024)_
 [^🛸]: Source: _Spelljammer: Adventures in Space_
 [^🎓]: Source: _Strixhaven: Curriculum of Chaos_
-[^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^📒1️⃣]: Source: _SRD 5.1_
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🌫️]: Source: _Van Richten's Guide to Ravenloft_
@@ -230,5 +187,3 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halfling.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
-[^😈]: The Tiefling was updated in _SRD 5.2_ to provide a Fiendish Legacies option. The Infernal Tiefling is mechanically equivalent to a Tiefling in _SRD 5.1_ or an Asmodeus Tiefling in _Mordenkainen's Tome of Foes_. The other ancestries are not mechanically equivalent to any prior Tiefling options, but the Abyssal Tiefling shares some spells with the Baalzebul Tiefling in _Mordenkainen's Tome of Foes_ (see the **[Infernal Tieflings](#infernal-tieflings)**[^👿] table).
-[^👿]: These classifications of Tiefling variants were added in _Mordenkainen's Tome of Foes_ to describe Tieflings with special links to one of the Lords of the Nine Hells, and they have thus been grouped together as variant Infernal Tieflings. The Asmodeus Tiefling is mechanically equivalent to an Infernal Tiefling in _SRD 5.2_. The other ancestries are not mechanically equivalent to any other Tiefling options, but the Baalzebul Tiefling shares some spells with the Abyssal Tiefling in _SRD 5.2_.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -30,7 +30,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 9  | Dragonborn (roll on **[Dragonborn](dragonborn.md)** table for setting) |
 | 10 | Dwarf (roll on **[Dwarves](dwarves.md)** table for setting) |
 | 11 | Elf (roll on **[Elves](elves.md)** table for setting) |
-| 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
+| 12 | Fairy (roll on **[Fairies](fairies.md)** table for ancestry) |
 | 13 | Firbolg[^👹] |
 | 14 | Flamekin[^🌄][^☄️] |
 | 15 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
@@ -98,18 +98,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Changeling[^👹] |
 | 2 | Lorwyn Changeling[^🌄] |
-
-#### Fairies
-| d2 | Ancestry |
-|:-:|:-|
-| 1 | Fairy[^👹] |
-| 2 | Lorwyn-Shadowmoor Fairy (roll on **[Lorwyn-Shadowmoor Fairies](#lorwyn-shadowmoor-fairies)** for variant) |
-
-##### Lorwyn-Shadowmoor Fairies
-| d2 | Variant |
-|:-:|:-|
-| 1 | Lorwyn Fairy[^🌄][^🧚] |
-| 2 | Shadowmoor Fairy[^🌄][^🧚] |
 
 #### Genasi
 | d4 | Ancestry |
@@ -278,7 +266,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🌫️]: Source: _Van Richten's Guide to Ravenloft_
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not mechanically equivalent to any single prior Aasimar option.
-[^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halfling.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -37,7 +37,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 16 | Giff[^🛸] |
 | 17 | Gith (roll on **[Gith](#gith)** table for ancestry) |
 | 18 | Gnome (roll on **[Gnomes](gnomes.md)** table for setting) |
-| 19 | Goblinoid (roll on **[Goblinoids](#goblinoids)** table for setting) |
+| 19 | Goblinoid (roll on **[Goblinoids](goblinoids.md)** table for setting) |
 | 20 | Goliath (roll on **[Giant Ancestry](#giant-ancestry)**[^🧌] table for ancestry) |
 | 21 | Grung[^🐸] |
 | 22 | Hadozee[^🛸] |
@@ -134,43 +134,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Githyanki[^👹] |
 | 2 | Githzerai[^👹] |
-
-#### Goblinoids
-| d5 | Setting |
-|:-:|:-|
-| 1 | Goblinoid of the Multiverse (roll on **[Goblinoids of the Multiverse](#goblinoids-of-the-multiverse)** table for variant) |
-| 2 | Boggart (roll on **[Boggarts](#boggarts)** table for variant) |
-| 3 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** table for variant) |
-| 4 | Ixalan Goblin[^🦕] |
-| 5 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
-
-##### Goblinoids of the Multiverse
-| d3 | Variant |
-|:-:|:-|
-| 1 | Bugbear[^👹] |
-| 2 | Goblin[^👹] |
-| 3 | Hobgoblin[^👹] |
-
-##### Boggarts
-| d2 | Variant |
-|:-:|:-|
-| 1 | Lorwyn Boggart[^🌄][^🐒] |
-| 2 | Shadowmoor Boggart[^🌄][^🐒] |
-
-##### Forgotten Realms Goblinoids
-| d4 | Variant |
-|:-:|:-|
-| 1 | Bugbear[^👹] |
-| 2 | Goblin[^👹] |
-| 3 | Hobgoblin[^👹] |
-| 4 | Verdan[^💰] |
-
-##### Zendikar Goblins
-| d3 | Variant |
-|:-:|:-|
-| 1 | Grotag Tribe Goblin[^🌴] |
-| 2 | Lavastep Tribe Goblin[^🌴] |
-| 3 | Tuktuk Tribe Goblin[^🌴] |
 
 #### Halflings
 | d4 | Setting |
@@ -361,7 +324,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 
 ---
 
-[^💰]: Source: _Acquisitions Incorporated_
 [^🫅]: Source: _Dragonlance: Shadow of the Dragon Queen_
 [^🦹]: Source: _Dungeon Master's Guide (2014)_
 [^⚙️]: Source: _Eberron: Rising from the Last War_
@@ -389,7 +351,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🌫️]: Source: _Van Richten's Guide to Ravenloft_
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not mechanically equivalent to any single prior Aasimar option.
-[^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -28,7 +28,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 7  | Centaur[^👹] |
 | 8  | Changeling (roll on **[Changelings](#changelings)** table for ancestry) |
 | 9  | Dragonborn (roll on **[Dragonborn](dragonborn.md)** table for setting) |
-| 10 | Dwarf (roll on **[Dwarves](#dwarves)** table for setting) |
+| 10 | Dwarf (roll on **[Dwarves](dwarves.md)** table for setting) |
 | 11 | Elf (roll on **[Elves](#elves)** table for setting) |
 | 12 | Fairy (roll on **[Fairies](#fairies)** table for ancestry) |
 | 13 | Firbolg[^👹] |
@@ -98,42 +98,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Changeling[^👹] |
 | 2 | Lorwyn Changeling[^🌄] |
-
-#### Dwarves
-| d5 | Setting |
-|:-:|:-|
-| 1 | Dwarf of the Multiverse (roll on **[Dwarves of the Multiverse](#dwarves-of-the-multiverse)** table for variant) |
-| 2 | Dragonlance Dwarf (roll on **[Dragonlance Dwarves](#dragonlance-dwarves)** table for variant) |
-| 3 | Eberron Dwarf (roll on **[Eberron Dwarves](#eberron-dwarves)** for variant) |
-| 4 | Forgotten Realms Dwarf (roll on **[Forgotten Realms Dwarves](#forgotten-realms-dwarves)** for variant) |
-| 5 | Kaladesh Dwarf[^🕰️] |
-
-##### Dwarves of the Multiverse
-| d3 | Variant |
-|:-:|:-|
-| 1 | Dwarf[^📒2️⃣][^🪓] |
-| 2 | Duergar[^👹][^🪓] |
-| 3 | Mountain Dwarf[^🔰1️⃣][^🪓] |
-
-##### Dragonlance Dwarves
-| d2 | Variant |
-|:-:|:-|
-| 1 | Hill Dwarf[^🪓] |
-| 2 | Mountain Dwarf[^🔰1️⃣] |
-
-##### Eberron Dwarves
-| d3 | Variant |
-|:-:|:-|
-| 1 | Hill Dwarf[^🪓] |
-| 2 | Mark of Warding Dwarf[^⚙️] |
-| 3 | Mountain Dwarf[^🔰1️⃣] |
-
-##### Forgotten Realms Dwarves
-| d3 | Variant |
-|:-:|:-|
-| 1 | Duergar[^👹][^🪓] |
-| 2 | Gold Dwarf[^📒2️⃣][^🪓] |
-| 3 | Shield Dwarf[^🔰1️⃣][^🪓] |
 
 #### Elves
 | d9 | Setting |
@@ -553,7 +517,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not mechanically equivalent to any single prior Aasimar option.
 [^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.
-[^🪓]: The Dwarf was updated in _SRD 5.2_ to remove ancestry selection. The Gold Dwarf and Shield Dwarf of the Forgotten Realms are mechanically equivalent to a Dwarf in _SRD 5.2_ and a Hill Dwarf in _SRD 5.1_, and the Duergar in _Mordenkainen Presents: Monsters of the Multiverse_ is mechanically equivalent to a Gray Dwarf in _Sword Coast Adventurer's Guide_.
 [^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms are mechanically equivalent to a High Elf in _SRD 5.2_, and the Joraga Nation Elf of Zendikar is mechanically equivalent to a Wood Elf in _SRD 5.2_.
 [^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
 [^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -56,7 +56,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 35 | Lizardfolk[^👹] |
 | 36 | Locathah[^🐟] |
 | 37 | Loxodon[^🏙️] |
-| 38 | Merfolk (roll on **[Merfolk](#merfolk)** table for setting) |
+| 38 | Merfolk (roll on **[Merfolk](merfolk.md)** table for setting) |
 | 39 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
 | 40 | Naga[^☥] |
 | 41 | Orc (roll on **[Orcs](#orcs)** table for setting) |
@@ -128,25 +128,6 @@ The reincarnated creature makes any choices that a species' description offers, 
 |:-:|:-|
 | 1 | Lorwyn Kithkin[^🌄][^🥑] |
 | 2 | Shadowmoor Kithkin[^🌄][^🥑] |
-
-#### Merfolk
-| d2 | Setting |
-|:-:|:-|
-| 1 | Ixalan Merfolk (roll on **[Ixalan Merfolk](#ixalan-merfolk)** table for variant) |
-| 2 | Zendikar Merfolk (roll on **[Zendikar Merfolk](#zendikar-merfolk)** table for variant) |
-
-##### Ixalan Merfolk
-| d2 | Variant |
-|:-:|:-|
-| 1 | Green Merfolk[^🦕] |
-| 2 | Blue Merfolk[^🦕] |
-
-##### Zendikar Merfolk
-| d3 | Variant |
-|:-:|:-|
-| 1 | Cosi Creed Merfolk[^🌴] |
-| 2 | Emeria (Wind) Creed Merfolk[^🌴] |
-| 3 | Ula (Water) Creed Merfolk[^🌴] |
 
 #### Minotaur
 | d2 | Ancestry |

--- a/docs/dragonborn.md
+++ b/docs/dragonborn.md
@@ -1,0 +1,58 @@
+# Dragonborn
+
+### Dragonborn
+| d2 | Setting |
+|:-:|:-|
+| 1 | Dragonborn of the Multiverse (roll on **[Draconic Ancestor](#draconic-ancestor)** table for ancestry) |
+| 2 | Exandrian Dragonborn (roll on **[Exandrian Dragonborn](#exandrian-dragonborn)** table for variant) |
+
+#### Draconic Ancestor
+| d3 | Ancestry |
+|:-:|:-|
+| 1 | Chromatic Dragonborn (roll on **[Chromatic Dragonborn](#chromatic-dragonborn)** table for color) |
+| 2 | Gem Dragonborn (roll on **[Gem Dragonborn](#gem-dragonborn)** table for gemstone) |
+| 3 | Metallic Dragonborn (roll on **[Metallic Dragonborn](#metallic-dragonborn)** table for metal) |
+
+##### Chromatic Dragonborn
+| d5 | Color |
+|:-:|:-|
+| 1 | Black[^📒2️⃣] |
+| 2 | Blue[^📒2️⃣] |
+| 3 | Green[^📒2️⃣] |
+| 4 | Red[^📒2️⃣] |
+| 5 | White[^📒2️⃣] |
+
+##### Gem Dragonborn
+| d5 | Gemstone |
+|:-:|:-|
+| 1 | Amethyst[^🐉] |
+| 2 | Crystal[^🐉]|
+| 3 | Emerald[^🐉] |
+| 4 | Sapphire[^🐉] |
+| 5 | Topaz[^🐉] |
+
+##### Metallic Dragonborn
+| d5 | Metal |
+|:-:|:-|
+| 1 | Brass[^📒2️⃣] |
+| 2 | Bronze[^📒2️⃣] |
+| 3 | Copper[^📒2️⃣] |
+| 4 | Gold[^📒2️⃣] |
+| 5 | Silver[^📒2️⃣] |
+
+#### Exandrian Dragonborn
+| d2 | Variant |
+|:-:|:-|
+| 1 | Draconblood Dragonborn[^⏳] |
+| 2 | Ravenite Dragonborn[^⏳] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⏳]: Source: _Explorer's Guide to Wildemount_
+[^🐉]: Source: _Fizban's Treasury of Dragons_
+[^📒2️⃣]: Source: _SRD 5.2_

--- a/docs/dwarves.md
+++ b/docs/dwarves.md
@@ -1,0 +1,51 @@
+# Dwarves
+
+#### Dwarves
+| d5 | Setting |
+|:-:|:-|
+| 1 | Dwarf of the Multiverse (roll on **[Dwarves of the Multiverse](#dwarves-of-the-multiverse)** table for variant) |
+| 2 | Dragonlance Dwarf (roll on **[Dragonlance Dwarves](#dragonlance-dwarves)** table for variant) |
+| 3 | Eberron Dwarf (roll on **[Eberron Dwarves](#eberron-dwarves)** for variant) |
+| 4 | Forgotten Realms Dwarf (roll on **[Forgotten Realms Dwarves](#forgotten-realms-dwarves)** for variant) |
+| 5 | Kaladesh Dwarf[^🕰️] |
+
+##### Dwarves of the Multiverse
+| d3 | Variant |
+|:-:|:-|
+| 1 | Dwarf[^📒2️⃣][^🪓] |
+| 2 | Duergar[^👹][^🪓] |
+| 3 | Mountain Dwarf[^🔰1️⃣][^🪓] |
+
+##### Dragonlance Dwarves
+| d2 | Variant |
+|:-:|:-|
+| 1 | Hill Dwarf[^🪓] |
+| 2 | Mountain Dwarf[^🔰1️⃣] |
+
+##### Eberron Dwarves
+| d3 | Variant |
+|:-:|:-|
+| 1 | Hill Dwarf[^📒2️⃣][^🪓] |
+| 2 | Mark of Warding Dwarf[^⚙️] |
+| 3 | Mountain Dwarf[^🔰1️⃣][^🪓] |
+
+##### Forgotten Realms Dwarves
+| d3 | Variant |
+|:-:|:-|
+| 1 | Duergar[^👹][^🪓] |
+| 2 | Gold Dwarf[^📒2️⃣][^🪓] |
+| 3 | Shield Dwarf[^🔰1️⃣][^🪓] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
+[^🕰️]: Source: _Plane Shift: Kaladesh_
+[^🔰1️⃣]: Source: _Player's Handbook (2014)_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🪓]: The Dwarf was updated in _SRD 5.2_ to remove ancestry selection. The Gold Dwarf and Shield Dwarf of the Forgotten Realms are mechanically equivalent to a Dwarf in _SRD 5.2_ and a Hill Dwarf in _SRD 5.1_, and the Duergar in _Mordenkainen Presents: Monsters of the Multiverse_ is mechanically equivalent to a Gray Dwarf in _Sword Coast Adventurer's Guide_.

--- a/docs/dwarves.md
+++ b/docs/dwarves.md
@@ -1,6 +1,6 @@
 # Dwarves
 
-#### Dwarves
+### Dwarves
 | d5 | Setting |
 |:-:|:-|
 | 1 | Dwarf of the Multiverse (roll on **[Dwarves of the Multiverse](#dwarves-of-the-multiverse)** table for variant) |
@@ -9,27 +9,27 @@
 | 4 | Forgotten Realms Dwarf (roll on **[Forgotten Realms Dwarves](#forgotten-realms-dwarves)** for variant) |
 | 5 | Kaladesh Dwarf[^🕰️] |
 
-##### Dwarves of the Multiverse
+#### Dwarves of the Multiverse
 | d3 | Variant |
 |:-:|:-|
 | 1 | Dwarf[^📒2️⃣][^🪓] |
 | 2 | Duergar[^👹][^🪓] |
 | 3 | Mountain Dwarf[^🔰1️⃣][^🪓] |
 
-##### Dragonlance Dwarves
+#### Dragonlance Dwarves
 | d2 | Variant |
 |:-:|:-|
 | 1 | Hill Dwarf[^🪓] |
 | 2 | Mountain Dwarf[^🔰1️⃣] |
 
-##### Eberron Dwarves
+#### Eberron Dwarves
 | d3 | Variant |
 |:-:|:-|
 | 1 | Hill Dwarf[^📒2️⃣][^🪓] |
 | 2 | Mark of Warding Dwarf[^⚙️] |
 | 3 | Mountain Dwarf[^🔰1️⃣][^🪓] |
 
-##### Forgotten Realms Dwarves
+#### Forgotten Realms Dwarves
 | d3 | Variant |
 |:-:|:-|
 | 1 | Duergar[^👹][^🪓] |

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -1,0 +1,120 @@
+# Elves
+
+### Elves
+| d9 | Setting |
+|:-:|:-|
+| 1 | Elf of the Multiverse (roll on **[Elven Lineages](#elven-lineages)** table for lineage) |
+| 2 | Dragonlance Elf (roll on **[Dragonlance Elves](#dragonlance-elves)** table for variant) |
+| 3 | Eberron Elf (roll on **[Eberron Elves](#eberron-elves)** table for variant) |
+| 4 | Exandrian Elf (roll on **[Exandrian Elves](#exandrian-elves)** table for variant) |
+| 5 | Forgotten Realms Elf (roll on **[Forgotten Realms Elves](#forgotten-realms-elves)** table for variant) |
+| 6 | Kaladesh Elf (roll on **[Kaladesh Elves](#kaladesh-elves)** table for variant) |
+| 7 | Lorwyn-Shadowmoor Elf (roll on **[Lorwyn-Shadowmoor Elves](#lorwyn-shadowmoor-elves)** table for variant) |
+| 8 | Ravnica Elf (roll on **[Ravnica Elves](#ravnica-elves)** table for variant) |
+| 9 | Zendikar Elf (roll on **[Zendikar Elves](#zendikar-elves)** table for variant) |
+
+#### Elven Lineages
+| d8 | Lineage |
+|:-:|:-|
+| 1 | Astral Elf[^🛸] |
+| 2 | Drow[^📒2️⃣] |
+| 3 | Eladrin[^👹] |
+| 4 | Half-Elf[^📒1️⃣] |
+| 5 | High Elf[^📒2️⃣] |
+| 6 | Sea Elf[^👹] |
+| 7 | Shadar-kai[^👹] |
+| 8 | Wood Elf[^📒2️⃣] |
+
+#### Dragonlance Elves
+| d3 | Variant |
+|:-:|:-|
+| 1 | High Elf[^📒2️⃣][^🏹] |
+| 2 | Sea Elf[^👹] |
+| 3 | Wood Elf[^📒2️⃣][^🏹] |
+
+#### Eberron Elves
+| d11 | Variant |
+|:-:|:-|
+| 1 | Aereni High Elf[^🧭] |
+| 2 | Aereni Wood Elf[^🧭] |
+| 3 | Drow[^📒2️⃣] |
+| 4 | Half-Elf[^📒1️⃣] |
+| 5 | High Elf[^📒2️⃣] |
+| 6 | Mark of Detection Half-Elf[^⚙️] |
+| 7 | Mark of Shadow Elf[^⚙️] |
+| 8 | Mark of Storm Half-Elf[^⚙️] |
+| 9 | Valenar High Elf[^🧭] |
+| 10 | Valenar Wood Elf[^🧭] |
+| 11 | Wood Elf[^📒2️⃣] |
+
+#### Exandrian Elves
+| d6 | Variant |
+|:-:|:-|
+| 1 | Drow[^📒2️⃣] |
+| 2 | Half-Elf[^📒1️⃣] |
+| 3 | High Elf[^📒2️⃣] |
+| 4 | Pallid Elf[^⏳] |
+| 5 | Sea Elf[^👹] |
+| 6 | Wood Elf[^📒2️⃣] |
+
+#### Forgotten Realms Elves
+| d10 | Variant |
+|:-:|:-|
+| 1 | Aquatic Half-Elf[^🗡️] |
+| 2 | Drow[^📒2️⃣] |
+| 3 | Drow Half-Elf[^🗡️] |
+| 4 | Half-Elf[^📒1️⃣] |
+| 5 | Moon Elf[^📒2️⃣][^🏹] |
+| 6 | Moon Half-Elf[^🗡️] |
+| 7 | Sun Elf[^📒2️⃣][^🏹] |
+| 8 | Sun Half-Elf[^🗡️] |
+| 9 | Wood Elf[^📒2️⃣] |
+| 10 | Wood Half-Elf[^🗡️] |
+
+#### Kaladesh Elves
+| d3 | Variant |
+|:-:|:-|
+| 1 | Bishtahar Elf[^🕰️] |
+| 2 | Tirahar Elf[^🕰️] |
+| 3 | Vahadar Elf[^🕰️] |
+
+#### Lorwyn-Shadowmoor Elves
+| d2 | Lineage |
+|:-:|:-|
+| 1 | Lorwyn Elf[^🌄] |
+| 2 | Shadowmoor Elf[^🌄] |
+
+#### Ravnica Elves
+| d4 | Variant |
+|:-:|:-|
+| 1 | Drow[^📒2️⃣] |
+| 2 | Half-Elf[^📒1️⃣] |
+| 3 | High Elf[^📒2️⃣] |
+| 4 | Wood Elf[^📒2️⃣] |
+
+#### Zendikar Elves
+| d3 | Variant |
+|:-:|:-|
+| 1 | Joraga Nation Elf[^🏹] |
+| 2 | Mul Daya Nation Elf[^🌴] |
+| 3 | Tajuru Nation Elf[^🌴] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^⏳]: Source: _Explorer's Guide to Wildemount_
+[^🌄]: Source: _Lorwyn: First Light_
+[^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
+[^🕰️]: Source: _Plane Shift: Kaladesh_
+[^🌴]: Source: _Plane Shift: Zendikar_
+[^🛸]: Source: _Spelljammer: Adventures in Space_
+[^📒1️⃣]: Source: _SRD 5.1_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🗡️]: Source: _Sword Coast Adventurer's Guide_
+[^🧭]: Source: _Wayfinder's Guide to Eberron_
+[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms are mechanically equivalent to a High Elf in _SRD 5.2_, and the Joraga Nation Elf of Zendikar is mechanically equivalent to a Wood Elf in _SRD 5.2_.

--- a/docs/fairies.md
+++ b/docs/fairies.md
@@ -1,0 +1,24 @@
+# Fairies
+
+### Fairies
+| d2 | Ancestry |
+|:-:|:-|
+| 1 | Fairy[^👹] |
+| 2 | Lorwyn-Shadowmoor Fairy (roll on **[Lorwyn-Shadowmoor Fairies](#lorwyn-shadowmoor-fairies)** for variant) |
+
+#### Lorwyn-Shadowmoor Fairies
+| d2 | Variant |
+|:-:|:-|
+| 1 | Lorwyn Fairy[^🌄][^🧚] |
+| 2 | Shadowmoor Fairy[^🌄][^🧚] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^🌄]: Source: _Lorwyn: First Light_
+[^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
+[^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.

--- a/docs/gnomes.md
+++ b/docs/gnomes.md
@@ -1,0 +1,41 @@
+# Gnomes
+
+#### Gnomes
+| d3 | Setting |
+|:-:|:-|
+| 1 | Gnome of the Multiverse (roll on **[Gnomish Lineages](#gnomish-lineages)** table for ancestry) |
+| 2 | Dragonlance Gnome (roll on **[Dragonlance Gnomes](#dragonlance-gnomes)** table for variant) |
+| 3 | Eberron Gnome (roll on **[Eberron Gnomes](#eberron-gnomes)** table for variant) |
+
+##### Gnomish Lineages
+| d3 | Ancestry |
+|:-:|:-|
+| 1 | Deep Gnome[^🙈][^🍄] |
+| 2 | Forest Gnome[^📒2️⃣] |
+| 3 | Rock Gnome[^📒2️⃣] |
+
+##### Dragonlance Gnomes
+| d2 | Variant |
+|:-:|:-|
+| 1 | Forest Gnome[^📒2️⃣] |
+| 2 | Tinker Gnome[^🫅][^🍄] |
+
+##### Eberron Gnome
+| d3 | Variant |
+|:-:|:-|
+| 1 | Forest Gnome[^📒2️⃣] |
+| 2 | Mark of Scribing Gnome[^⚙️] |
+| 3 | Rock Gnome[^📒2️⃣] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^🫅]: Source: _Dragonlance: Shadow of the Dragon Queen_
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^🙈]: Source: _Elemental Evil Player's Companion_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_, and the Deep Gnome is mechanically equivalent to a Svirfneblin in _Elemental Evil Player's Companion_.

--- a/docs/gnomes.md
+++ b/docs/gnomes.md
@@ -1,26 +1,26 @@
 # Gnomes
 
-#### Gnomes
+### Gnomes
 | d3 | Setting |
 |:-:|:-|
 | 1 | Gnome of the Multiverse (roll on **[Gnomish Lineages](#gnomish-lineages)** table for ancestry) |
 | 2 | Dragonlance Gnome (roll on **[Dragonlance Gnomes](#dragonlance-gnomes)** table for variant) |
 | 3 | Eberron Gnome (roll on **[Eberron Gnomes](#eberron-gnomes)** table for variant) |
 
-##### Gnomish Lineages
+#### Gnomish Lineages
 | d3 | Ancestry |
 |:-:|:-|
 | 1 | Deep Gnome[^🙈][^🍄] |
 | 2 | Forest Gnome[^📒2️⃣] |
 | 3 | Rock Gnome[^📒2️⃣] |
 
-##### Dragonlance Gnomes
+#### Dragonlance Gnomes
 | d2 | Variant |
 |:-:|:-|
 | 1 | Forest Gnome[^📒2️⃣] |
 | 2 | Tinker Gnome[^🫅][^🍄] |
 
-##### Eberron Gnome
+#### Eberron Gnome
 | d3 | Variant |
 |:-:|:-|
 | 1 | Forest Gnome[^📒2️⃣] |

--- a/docs/goblinoids.md
+++ b/docs/goblinoids.md
@@ -1,6 +1,6 @@
 # Goblinoids
 
-#### Goblinoids
+### Goblinoids
 | d5 | Setting |
 |:-:|:-|
 | 1 | Goblinoid of the Multiverse (roll on **[Goblinoids of the Multiverse](#goblinoids-of-the-multiverse)** table for variant) |
@@ -9,20 +9,20 @@
 | 4 | Ixalan Goblin[^🦕] |
 | 5 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
 
-##### Goblinoids of the Multiverse
+#### Goblinoids of the Multiverse
 | d3 | Variant |
 |:-:|:-|
 | 1 | Bugbear[^👹] |
 | 2 | Goblin[^👹] |
 | 3 | Hobgoblin[^👹] |
 
-##### Boggarts
+#### Boggarts
 | d2 | Variant |
 |:-:|:-|
 | 1 | Lorwyn Boggart[^🌄][^🐒] |
 | 2 | Shadowmoor Boggart[^🌄][^🐒] |
 
-##### Forgotten Realms Goblinoids
+#### Forgotten Realms Goblinoids
 | d4 | Variant |
 |:-:|:-|
 | 1 | Bugbear[^👹] |
@@ -30,7 +30,7 @@
 | 3 | Hobgoblin[^👹] |
 | 4 | Verdan[^💰] |
 
-##### Zendikar Goblins
+#### Zendikar Goblins
 | d3 | Variant |
 |:-:|:-|
 | 1 | Grotag Tribe Goblin[^🌴] |

--- a/docs/goblinoids.md
+++ b/docs/goblinoids.md
@@ -1,0 +1,52 @@
+# Goblinoids
+
+#### Goblinoids
+| d5 | Setting |
+|:-:|:-|
+| 1 | Goblinoid of the Multiverse (roll on **[Goblinoids of the Multiverse](#goblinoids-of-the-multiverse)** table for variant) |
+| 2 | Boggart (roll on **[Boggarts](#boggarts)** table for variant) |
+| 3 | Forgotten Realms Goblinoid (roll on **[Forgotten Realms Goblinoid](#forgotten-realms-goblinoid)** table for variant) |
+| 4 | Ixalan Goblin[^🦕] |
+| 5 | Zendikar Goblin (roll on **[Zendikar Goblins](#zendikar-goblins)** table for variant) |
+
+##### Goblinoids of the Multiverse
+| d3 | Variant |
+|:-:|:-|
+| 1 | Bugbear[^👹] |
+| 2 | Goblin[^👹] |
+| 3 | Hobgoblin[^👹] |
+
+##### Boggarts
+| d2 | Variant |
+|:-:|:-|
+| 1 | Lorwyn Boggart[^🌄][^🐒] |
+| 2 | Shadowmoor Boggart[^🌄][^🐒] |
+
+##### Forgotten Realms Goblinoids
+| d4 | Variant |
+|:-:|:-|
+| 1 | Bugbear[^👹] |
+| 2 | Goblin[^👹] |
+| 3 | Hobgoblin[^👹] |
+| 4 | Verdan[^💰] |
+
+##### Zendikar Goblins
+| d3 | Variant |
+|:-:|:-|
+| 1 | Grotag Tribe Goblin[^🌴] |
+| 2 | Lavastep Tribe Goblin[^🌴] |
+| 3 | Tuktuk Tribe Goblin[^🌴] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^💰]: Source: _Acquisitions Incorporated_
+[^🌄]: Source: _Lorwyn: First Light_
+[^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
+[^🦕]: Source: _Plane Shift: Ixalan_
+[^🌴]: Source: _Plane Shift: Zendikar_
+[^🐒]: A Boggart in _Lorwyn: First Light_ is mechanically equivalent to a Goblin.

--- a/docs/halflings.md
+++ b/docs/halflings.md
@@ -1,0 +1,51 @@
+# Halflings
+
+### Halflings
+| d4 | Setting |
+|:-:|:-|
+| 1 | Halfling of the Multiverse (roll on **[Halflings of the Multiverse](#halflings-of-the-multiverse)** table for variant) |
+| 2 | Eberron Halfling (roll on **[Eberron Halflings](#eberron-halflings)** table for variant) |
+| 3 | Exandrian Halfling (roll on **[Exandrian Halflings](#exandrian-halflings)** table for variant) |
+| 4 | Forgotten Realms Halfling (roll on **[Forgotten Realms Halflings](#forgotten-realms-halflings)** for variant) |
+
+#### Halflings of the Multiverse
+| d2 | Variant |
+|:-:|:-|
+| 1 | Halfling[^📒2️⃣][^🥑] |
+| 2 | Stout Halfling[^🔰1️⃣] |
+
+#### Eberron Halflings
+| d4 | Variant |
+|:-:|:-|
+| 1 | Lightfoot Halfling[^📒2️⃣][^🥑] |
+| 2 | Mark of Healing Halfling[^⚙️] |
+| 3 | Mark of Hospitality Halfling[^⚙️] |
+| 4 | Stout Halfling[^🔰1️⃣][^🥑] |
+
+#### Exandrian Halflings
+| d3 | Variant |
+|:-:|:-|
+| 1 | Halfling[^📒2️⃣][^🥑] |
+| 2 | Lotusden Halfling[^⏳] |
+| 3 | Stout Halfling[^🔰1️⃣] |
+
+#### Forgotten Realms Halflings
+| d3 | Variant |
+|:-:|:-|
+| 1 | Lightfoot Halfling[^📒2️⃣][^🥑] |
+| 2 | Ghostwise Halfling[^🗡️] |
+| 3 | Strongheart Halfling[^🔰1️⃣][^🥑] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^⏳]: Source: _Explorer's Guide to Wildemount_
+[^🔰1️⃣]: Source: _Player's Handbook (2014)_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🗡️]: Source: _Sword Coast Adventurer's Guide_
+[^🥑]: The Halfling was updated in _SRD 5.2_ to remove ancestry selection. The Halfling is mechanically equivalent to a Lightfoot Halfling in _SRD 5.1_ and a Lorwyn Kithkin, a Strongheart Halfling of the Forgotten Realms can be represented either with a Halfling in _SRD 5.2_ or a Stout Halfling in _Player's Handbook (2014)_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.

--- a/docs/humans.md
+++ b/docs/humans.md
@@ -1,0 +1,48 @@
+# Humans
+
+### Humans
+| d4 | Setting |
+|:-:|:-|
+| 1 | Human of the Multiverse (roll on **[Humans of the Multiverse](#humans-of-the-multiverse)** table for variant) |
+| 2 | Eberron Human (roll on **[Eberron Humans](#eberron-humans)** table for variant) |
+| 3 | Innistrad Human (roll on **[Innistrad Provinces](#innistrad-provinces)** table for provincial origin) |
+| 4 | Keldon Human[^🛡️] |
+
+#### Humans of the Multiverse
+| d2 | Variant |
+|:-:|:-|
+| 1 | Human[^📒2️⃣][^👤] |
+| 2 | Human (2014)[^📒1️⃣] |
+
+#### Eberron Humans
+| d7 | Variant |
+|:-:|:-|
+| 1 | Human[^📒2️⃣][^👤] |
+| 2 | Human (2014)[^📒1️⃣] |
+| 3 | Mark of Finding Human[^⚙️] |
+| 4 | Mark of Handling Human[^⚙️] |
+| 5 | Mark of Making Human[^⚙️] |
+| 6 | Mark of Passage Human[^⚙️] |
+| 7 | Mark of Sentinel Human[^⚙️] |
+
+#### Innistrad Provinces
+| d4 | Provincial Origin |
+|:-:|:-|
+| 1 | Gavony Human[^🧛] |
+| 2 | Kessig Human[^🧛] |
+| 3 | Nephalia Human[^🧛] |
+| 4 | Stensia Human[^🧛] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^🛡️]: Source: _Plane Shift: Dominaria_
+[^🧛]: Source: _Plane Shift: Innistrad_
+[^📒1️⃣]: Source: _SRD 5.1_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^👤]: The Human was updated in _SRD 5.2_ to remove variant selection and replaced the Human option from _SRD 5.1_, which this document labels as "Human (2014)" to distinguish the option. It is mechanically equivalent to a Variant Human in _Player's Handbook (2014)_.

--- a/docs/merfolk.md
+++ b/docs/merfolk.md
@@ -1,18 +1,18 @@
 # Merfolk
 
-#### Merfolk
+### Merfolk
 | d2 | Setting |
 |:-:|:-|
 | 1 | Ixalan Merfolk (roll on **[Ixalan Merfolk](#ixalan-merfolk)** table for variant) |
 | 2 | Zendikar Merfolk (roll on **[Zendikar Merfolk](#zendikar-merfolk)** table for variant) |
 
-##### Ixalan Merfolk
+#### Ixalan Merfolk
 | d2 | Variant |
 |:-:|:-|
 | 1 | Green Merfolk[^🦕] |
 | 2 | Blue Merfolk[^🦕] |
 
-##### Zendikar Merfolk
+#### Zendikar Merfolk
 | d3 | Variant |
 |:-:|:-|
 | 1 | Cosi Creed Merfolk[^🌴] |

--- a/docs/merfolk.md
+++ b/docs/merfolk.md
@@ -1,0 +1,30 @@
+# Merfolk
+
+#### Merfolk
+| d2 | Setting |
+|:-:|:-|
+| 1 | Ixalan Merfolk (roll on **[Ixalan Merfolk](#ixalan-merfolk)** table for variant) |
+| 2 | Zendikar Merfolk (roll on **[Zendikar Merfolk](#zendikar-merfolk)** table for variant) |
+
+##### Ixalan Merfolk
+| d2 | Variant |
+|:-:|:-|
+| 1 | Green Merfolk[^🦕] |
+| 2 | Blue Merfolk[^🦕] |
+
+##### Zendikar Merfolk
+| d3 | Variant |
+|:-:|:-|
+| 1 | Cosi Creed Merfolk[^🌴] |
+| 2 | Emeria (Wind) Creed Merfolk[^🌴] |
+| 3 | Ula (Water) Creed Merfolk[^🌴] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^🦕]: Source: _Plane Shift: Ixalan_
+[^🌴]: Source: _Plane Shift: Zendikar_

--- a/docs/orcs.md
+++ b/docs/orcs.md
@@ -1,0 +1,34 @@
+# Orcs
+
+### Orcs
+| d3 | Setting |
+|:-:|:-|
+| 1 | Orc of the Multiverse (roll on **[Orcs of the Multiverse](#orcs-of-the-multiverse)** table for variant) |
+| 2 | Eberron Orc (roll on **[Eberron Orcs](#eberron-orcs)** table for variant) |
+| 3 | Ixalan Orc[^🦕][^🍖] |
+
+#### Orcs of the Multiverse
+| d2 | Variant |
+|:-:|:-|
+| 1 | Orc[^📒2️⃣][^🍖] |
+| 2 | Half-Orc[^📒1️⃣][^🍖] |
+
+#### Eberron Orcs
+| d3 | Variant |
+|:-:|:-|
+| 1 | Half-Orc[^📒1️⃣][^🍖] |
+| 2 | Mark of Finding Half-Orc[^⚙️] |
+| 3 | Orc[^📒2️⃣][^🍖] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^⚙️]: Source: _Eberron: Rising from the Last War_
+[^🦕]: Source: _Plane Shift: Ixalan_
+[^📒1️⃣]: Source: _SRD 5.1_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🍖]: The Orc replaced the Half-Orc option from _SRD 5.1_. The Ixalan Orc is mechanically equivalent to a Half-Orc.

--- a/docs/tieflings.md
+++ b/docs/tieflings.md
@@ -1,0 +1,55 @@
+# Tieflings
+
+### Tieflings
+| d2 | Setting |
+|:--:|:-|
+| 1 | Tiefling of the Multiverse (roll on **[Fiendish Legacies](#fiendish-legacies)**[^😈] table for ancestry) |
+| 2 | Forgotten Realms Tiefling (roll on **[Forgotten Realms Tieflings](#forgotten-realms-tieflings)** table for variant) |
+
+#### Fiendish Legacies
+| d3 | Ancestry |
+|:--:|:-|
+| 1 | Abyssal Tiefling[^📒2️⃣] |
+| 2 | Chthonic Tiefling[^📒2️⃣] |
+| 3 | Infernal Tiefling (roll on **[Infernal Tieflings](#infernal-tieflings)**[^👿] table for variant) |
+
+##### Infernal Tieflings
+| d9 | Variant |
+|:--:|:-|
+| 1 | Asmodeus Tiefling[^📒2️⃣][^😈] |
+| 2 | Baalzebul Tiefling[^👺] |
+| 3 | Dispater Tiefling[^👺] |
+| 4 | Fierna Tiefling[^👺] |
+| 5 | Glasya Tiefling[^👺] |
+| 6 | Levistus Tiefling[^👺] |
+| 7 | Mammon Tiefling[^👺] |
+| 8 | Mephistopheles Tiefling[^👺] |
+| 9 | Zariel Tiefling[^👺] |
+
+#### Forgotten Realms Tieflings
+| d4 | Variant |
+|:-:|:-|
+| 1 | Abyssal Tiefling[^📒2️⃣] |
+| 2 | Chthonic Tiefling[^📒2️⃣] |
+| 3 | Infernal Tiefling (roll on **[Infernal Tieflings](#infernal-tieflings)**[^👿] table for variant) |
+| 4 | Feral Tiefling (roll on **[Feral Tieflings](#feral-tieflings)** table for variant) |
+
+##### Feral Tieflings
+| d3 | Variant |
+|:-:|:-|
+| 1 | Devil's Tongue Feral Tiefling[^🗡️] |
+| 2 | Hellfire Feral Tiefling[^🗡️] |
+| 3 | Winged Feral Tiefling[^🗡️] |
+
+---
+
+| ⬅️ Back to Reincarnation Options](ch-2-reincarnate.md) |
+|-:|
+
+---
+
+[^👺]: Source: _Mordenkainen's Tome of Foes_
+[^📒2️⃣]: Source: _SRD 5.2_
+[^🗡️]: Source: _Sword Coast Adventurer's Guide_
+[^😈]: The Tiefling was updated in _SRD 5.2_ to provide a Fiendish Legacies option. The Infernal Tiefling is mechanically equivalent to a Tiefling in _SRD 5.1_ or an Asmodeus Tiefling in _Mordenkainen's Tome of Foes_. The other ancestries are not mechanically equivalent to any prior Tiefling options, but the Abyssal Tiefling shares some spells with the Baalzebul Tiefling in _Mordenkainen's Tome of Foes_ (see the **[Infernal Tieflings](#infernal-tieflings)**[^👿] table).
+[^👿]: These classifications of Tiefling variants were added in _Mordenkainen's Tome of Foes_ to describe Tieflings with special links to one of the Lords of the Nine Hells, and they have thus been grouped together as variant Infernal Tieflings. The Asmodeus Tiefling is mechanically equivalent to an Infernal Tiefling in _SRD 5.2_. The other ancestries are not mechanically equivalent to any other Tiefling options, but the Baalzebul Tiefling shares some spells with the Abyssal Tiefling in _SRD 5.2_.


### PR DESCRIPTION
- split multi-table species into dedicated pages:
  - Dragonborn
  - Dwarves
  - Elves
  - Fairies
  - Gnomes
  - Goblinoids
  - Halflings
  - Humans
  - Merfolk
  - Orcs
  - Tieflings