### PR TITLE
corrected source footnotes based on current Sourcing priority

### DIFF
--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -187,4 +187,4 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🎭]: The Lorwyn Changeling is mechanically equivalent to a Changeling in _Mordenkainen Presents: Monsters of the Multiverse_.
 [^☄️]: The Flamekin is mechanically equivalent to a Fire Genasi in _Elemental Evil Player's Companion_.
 [^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in previous releases, but the other ancestries are not mechanically equivalent to any prior Goliath options.
-[^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halflings.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.
+[^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halflings.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species.

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -32,7 +32,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 11 | Elf (roll on **[Elves](elves.md)** table for setting) |
 | 12 | Fairy (roll on **[Fairies](fairies.md)** table for ancestry) |
 | 13 | Firbolg[^👹] |
-| 14 | Flamekin[^🌄] [^☄️] |
+| 14 | Flamekin[^🙈] [^☄️] |
 | 15 | Genasi (roll on **[Genasi](#genasi)** table for ancestry) |
 | 16 | Giff[^🛸] |
 | 17 | Gith (roll on **[Gith](#gith)** table for ancestry) |
@@ -97,7 +97,7 @@ The reincarnated creature makes any choices that a species' description offers, 
 | d2 | Ancestry |
 |:-:|:-|
 | 1 | Changeling[^👹] |
-| 2 | Lorwyn Changeling[^🌄] |
+| 2 | Lorwyn Changeling[^👹] [^🎭] |
 
 #### Genasi
 | d4 | Ancestry |
@@ -126,8 +126,8 @@ The reincarnated creature makes any choices that a species' description offers, 
 #### Kithkin
 | d2 | Ancestry |
 |:-:|:-|
-| 1 | Lorwyn Kithkin[^🌄] [^🥑] |
-| 2 | Shadowmoor Kithkin[^🌄] [^🥑] |
+| 1 | Lorwyn Kithkin[^📒2️⃣] [^🥑] |
+| 2 | Shadowmoor Kithkin[^📒2️⃣] [^🥑] |
 
 #### Minotaur
 | d2 | Ancestry |
@@ -183,7 +183,8 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^📒1️⃣]: Source: _SRD 5.1_
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🌫️]: Source: _Van Richten's Guide to Ravenloft_
-[^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The updated Aasimar is not mechanically equivalent to any single prior Aasimar option.
-[^☄️]: A Flamekin in _Lorwyn: First Light_ is mechanically equivalent to a Fire Genasi.
-[^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in _Elemental Evil Player's Companion_. The other ancestries are not mechanically equivalent to any prior Goliath options.
+[^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The Aasimar is not mechanically equivalent to any single prior Aasimar option.
+[^🎭]: The Lorwyn Changeling is mechanically equivalent to a Changeling in _Mordenkainen Presents: Monsters of the Multiverse_.
+[^☄️]: The Flamekin is mechanically equivalent to a Fire Genasi in _Elemental Evil Player's Companion_.
+[^🧌]: The Goliath was updated in _SRD 5.2_ to provide a Giant Ancestry option. The Stone Giant Goliath is mechanically equivalent to a Goliath in previous releases, but the other ancestries are not mechanically equivalent to any prior Goliath options.
 [^🥑]: The Lorwyn Kithkin is mechanically equivalent to a [Halfling](halflings.md) in _SRD 5.2_, and a Shadowmoor Kithkin only adds Darkvision (120 feet) to the Halfling species option.

--- a/docs/dwarves.md
+++ b/docs/dwarves.md
@@ -19,7 +19,7 @@
 #### Dragonlance Dwarves
 | d2 | Variant |
 |:-:|:-|
-| 1 | Hill Dwarf[^🪓] |
+| 1 | Hill Dwarf[^📒2️⃣] [^🪓] |
 | 2 | Mountain Dwarf[^🔰1️⃣] |
 
 #### Eberron Dwarves

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -116,4 +116,4 @@
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf or Zendikar only removes the Trance trait from the Wood Elf lineage.
+[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf of Zendikar only removes the Trance trait from the Wood Elf lineage.

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -95,7 +95,7 @@
 #### Zendikar Elves
 | d3 | Variant |
 |:-:|:-|
-| 1 | Joraga Nation Elf[^🌴] |
+| 1 | Joraga Nation Elf[^📒2️⃣] [^🏹] |
 | 2 | Mul Daya Nation Elf[^🌴] |
 | 3 | Tajuru Nation Elf[^🌴] |
 
@@ -116,4 +116,4 @@
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, and the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_.
+[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf only removes the Trance trait from the Wood Elf lineage.

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -74,9 +74,9 @@
 #### Kaladesh Elves
 | d3 | Variant |
 |:-:|:-|
-| 1 | Bishtahar Elf[^🕰️] |
-| 2 | Tirahar Elf[^🕰️] |
-| 3 | Vahadar Elf[^🕰️] |
+| 1 | Bishtahar Elf[^📒2️⃣] [^🏹] |
+| 2 | Tirahar Elf[^📒2️⃣] [^🏹] |
+| 3 | Vahadar Elf[^📒2️⃣] [^🏹] |
 
 #### Lorwyn-Shadowmoor Elves
 | d2 | Lineage |
@@ -95,7 +95,7 @@
 #### Zendikar Elves
 | d3 | Variant |
 |:-:|:-|
-| 1 | Joraga Nation Elf[^📒2️⃣] [^🏹] |
+| 1 | Joraga Nation Elf[^🌴] |
 | 2 | Mul Daya Nation Elf[^🌴] |
 | 3 | Tajuru Nation Elf[^🌴] |
 
@@ -110,11 +110,10 @@
 [^⏳]: Source: _Explorer's Guide to Wildemount_
 [^🌄]: Source: _Lorwyn: First Light_
 [^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
-[^🕰️]: Source: _Plane Shift: Kaladesh_
 [^🌴]: Source: _Plane Shift: Zendikar_
 [^🛸]: Source: _Spelljammer: Adventures in Space_
 [^📒1️⃣]: Source: _SRD 5.1_
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms are mechanically equivalent to a High Elf in _SRD 5.2_, the Joraga Nation Elf of Zendikar is mechanically equivalent to a Wood Elf in _SRD 5.2_, and the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_.
+[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, and the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_.

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -116,4 +116,4 @@
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf only removes the Trance trait from the Wood Elf lineage.
+[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf or Zendikar only removes the Trance trait from the Wood Elf lineage.

--- a/docs/fairies.md
+++ b/docs/fairies.md
@@ -21,4 +21,4 @@
 
 [^🌄]: Source: _Lorwyn: First Light_
 [^👹]: Source: _Mordenkainen Presents: Monsters of the Multiverse_
-[^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy in _Mordenkainen Presents: Monsters of the Multiverse_, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species option.
+[^🧚]: A Lorwyn Fairy in _Lorwyn: First Light_ is mechanically equivalent to a Fairy in _Mordenkainen Presents: Monsters of the Multiverse_, while a Shadowmoor Fairy in _Lorwyn: First Light_ only adds Darkvision (120 feet) to the Fairy species.

--- a/docs/fairies.md
+++ b/docs/fairies.md
@@ -9,8 +9,8 @@
 #### Lorwyn-Shadowmoor Fairies
 | d2 | Variant |
 |:-:|:-|
-| 1 | Lorwyn Fairy[^🌄] [^🧚] |
-| 2 | Shadowmoor Fairy[^🌄] [^🧚] |
+| 1 | Lorwyn Fairy[^👹] [^🧚] |
+| 2 | Shadowmoor Fairy[^👹] [^🧚] |
 
 ---
 

--- a/docs/goblinoids.md
+++ b/docs/goblinoids.md
@@ -19,8 +19,8 @@
 #### Boggarts
 | d2 | Variant |
 |:-:|:-|
-| 1 | Lorwyn Boggart[^🌄] [^🐒] |
-| 2 | Shadowmoor Boggart[^🌄] [^🐒] |
+| 1 | Lorwyn Boggart[^👹] [^🐒] |
+| 2 | Shadowmoor Boggart[^👹] [^🐒] |
 
 #### Forgotten Realms Goblinoids
 | d4 | Variant |

--- a/docs/orcs.md
+++ b/docs/orcs.md
@@ -5,20 +5,20 @@
 |:-:|:-|
 | 1 | Orc of the Multiverse (roll on **[Orcs of the Multiverse](#orcs-of-the-multiverse)** table for variant) |
 | 2 | Eberron Orc (roll on **[Eberron Orcs](#eberron-orcs)** table for variant) |
-| 3 | Ixalan Orc[^🦕] [^🍖] |
+| 3 | Ixalan Orc[^📒1️⃣] [^🍖] |
 
 #### Orcs of the Multiverse
 | d2 | Variant |
 |:-:|:-|
-| 1 | Half-Orc[^📒1️⃣] [^🍖] |
-| 2 | Orc[^📒2️⃣] [^🍖] |
+| 1 | Half-Orc[^📒1️⃣] |
+| 2 | Orc[^📒2️⃣] |
 
 #### Eberron Orcs
 | d3 | Variant |
 |:-:|:-|
-| 1 | Half-Orc[^📒1️⃣] [^🍖] |
+| 1 | Half-Orc[^📒1️⃣] |
 | 2 | Mark of Finding Half-Orc[^⚙️] |
-| 3 | Orc[^📒2️⃣] [^🍖] |
+| 3 | Orc[^📒2️⃣] |
 
 ---
 


### PR DESCRIPTION
- corrected source footnotes based on current Sourcing priority:
  - Flamekin: _Elemental Evil Player's Companion_ (**Free Beats Paid**)
  - Lorwyn Changeling: _Mordenkainen Presents: Monsters of the Multiverse_ (**More Beats Fewer**)
    - added footnote calling out mechanical equivalency
  - Kithkin: _SRD 5.2_ (**Free Beats Paid**)
  - Kaladesh Elves: _SRD 5.2_ (**New Beats Old**)
    - added footnote calling out mechanical equivalencies
  - Lorwyn-Shadowmoor Fairies: _Mordenkainen Presents: Monsters of the Multiverse_ (**More Beats Fewer**)
  - Boggarts: _Mordenkainen Presents: Monsters of the Multiverse_ (**More Beats Fewer**)
  - Ixalan Orc: _SRD 5.2_ (**New Beats Old**)
- removed unused Orc equivalency footnotes
- called out in Elf footnote that Joraga Nation Elf removes the Trance trait but otherwise matches Wood Elf mechanically