### PR TITLE
subdivided footnotes

### DIFF
--- a/docs/dwarves.md
+++ b/docs/dwarves.md
@@ -13,8 +13,8 @@
 | d3 | Variant |
 |:-:|:-|
 | 1 | Dwarf[^📒2️⃣] [^🪓] |
-| 2 | Duergar[^👹] [^🪓] |
-| 3 | Mountain Dwarf[^🔰1️⃣] [^🪓] |
+| 2 | Duergar[^👹] [^👽] |
+| 3 | Mountain Dwarf[^🔰1️⃣] |
 
 #### Dragonlance Dwarves
 | d2 | Variant |
@@ -27,12 +27,12 @@
 |:-:|:-|
 | 1 | Hill Dwarf[^📒2️⃣] [^🪓] |
 | 2 | Mark of Warding Dwarf[^⚙️] |
-| 3 | Mountain Dwarf[^🔰1️⃣] [^🪓] |
+| 3 | Mountain Dwarf[^🔰1️⃣] |
 
 #### Forgotten Realms Dwarves
 | d3 | Variant |
 |:-:|:-|
-| 1 | Duergar[^👹] [^🪓] |
+| 1 | Duergar[^👹] [^👽] |
 | 2 | Gold Dwarf[^📒2️⃣] [^🪓] |
 | 3 | Shield Dwarf[^🔰1️⃣] [^🪓] |
 
@@ -48,4 +48,5 @@
 [^🕰️]: Source: _Plane Shift: Kaladesh_
 [^🔰1️⃣]: Source: _Player's Handbook (2014)_
 [^📒2️⃣]: Source: _SRD 5.2_
-[^🪓]: The Dwarf was updated in _SRD 5.2_ to remove ancestry selection. The Gold Dwarf and Shield Dwarf of the Forgotten Realms are mechanically equivalent to a Dwarf in _SRD 5.2_ and a Hill Dwarf in _SRD 5.1_, and the Duergar in _Mordenkainen Presents: Monsters of the Multiverse_ is mechanically equivalent to a Gray Dwarf in _Sword Coast Adventurer's Guide_.
+[^🪓]: The Dwarf was updated in _SRD 5.2_ to remove ancestry selection. The Gold Dwarf and Shield Dwarf of the Forgotten Realms are mechanically equivalent to a Dwarf in _SRD 5.2_ and a Hill Dwarf in _SRD 5.1_.
+[^👽]: The Duergar in _Mordenkainen Presents: Monsters of the Multiverse_ is mechanically equivalent to a Gray Dwarf in _Sword Coast Adventurer's Guide_.

--- a/docs/elves.md
+++ b/docs/elves.md
@@ -28,9 +28,9 @@
 #### Dragonlance Elves
 | d3 | Variant |
 |:-:|:-|
-| 1 | High Elf[^📒2️⃣] [^🏹] |
+| 1 | High Elf[^📒2️⃣] |
 | 2 | Sea Elf[^👹] |
-| 3 | Wood Elf[^📒2️⃣] [^🏹] |
+| 3 | Wood Elf[^📒2️⃣] |
 
 #### Eberron Elves
 | d11 | Variant |
@@ -39,7 +39,7 @@
 | 2 | Aereni Wood Elf[^🧭] |
 | 3 | Drow[^📒2️⃣] |
 | 4 | High Elf[^📒2️⃣] |
-| 5 | Khoravar[^📒1️⃣] [^🏹] |
+| 5 | Khoravar[^📒1️⃣] [^☯️] |
 | 6 | Mark of Detection Half-Elf[^⚙️] |
 | 7 | Mark of Shadow Elf[^⚙️] |
 | 8 | Mark of Storm Half-Elf[^⚙️] |
@@ -64,9 +64,9 @@
 | 2 | Drow[^📒2️⃣] |
 | 3 | Drow Half-Elf[^🗡️] |
 | 4 | Half-Elf[^📒1️⃣] |
-| 5 | Moon Elf[^📒2️⃣] [^🏹] |
+| 5 | Moon Elf[^📒2️⃣] [^🧝] |
 | 6 | Moon Half-Elf[^🗡️] |
-| 7 | Sun Elf[^📒2️⃣] [^🏹] |
+| 7 | Sun Elf[^📒2️⃣] [^🧝] |
 | 8 | Sun Half-Elf[^🗡️] |
 | 9 | Wood Elf[^📒2️⃣] |
 | 10 | Wood Half-Elf[^🗡️] |
@@ -76,7 +76,7 @@
 |:-:|:-|
 | 1 | Bishtahar Elf[^📒2️⃣] [^🏹] |
 | 2 | Tirahar Elf[^📒2️⃣] [^🏹] |
-| 3 | Vahadar Elf[^📒2️⃣] [^🏹] |
+| 3 | Vahadar Elf[^📒2️⃣] [^🧝] |
 
 #### Lorwyn-Shadowmoor Elves
 | d2 | Lineage |
@@ -116,4 +116,6 @@
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🗡️]: Source: _Sword Coast Adventurer's Guide_
 [^🧭]: Source: _Wayfinder's Guide to Eberron_
-[^🏹]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_, the Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, the Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_, and the Joraga Nation Elf of Zendikar only removes the Trance trait from the Wood Elf lineage.
+[^🧝]: The Moon Elf and Sun Elf of the Forgotten Realms and the Vahadar Elf of Kaladesh are mechanically equivalent to a High Elf in _SRD 5.2_.
+[^🏹]: The Bishtahar and Tirahar Elf of Kaladesh are mechanically equivalent to a Wood Elf in _SRD 5.2_, and the Joraga Nation Elf of Zendikar only removes the Trance trait from the Wood Elf lineage.
+[^☯️]: The Khoravar of Eberron is mechanically equivalent to a Half-Elf in _SRD 5.1_.

--- a/docs/gnomes.md
+++ b/docs/gnomes.md
@@ -10,7 +10,7 @@
 #### Gnomish Lineages
 | d3 | Ancestry |
 |:-:|:-|
-| 1 | Deep Gnome[^🙈] [^🍄‍🟫] |
+| 1 | Deep Gnome[^🙈] [^🌑] |
 | 2 | Forest Gnome[^📒2️⃣] |
 | 3 | Rock Gnome[^📒2️⃣] |
 
@@ -39,4 +39,4 @@
 [^🙈]: Source: _Elemental Evil Player's Companion_
 [^📒2️⃣]: Source: _SRD 5.2_
 [^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_.
-[^🍄‍🟫]: The Deep Gnome is interchangeably known as a Svirfneblin.
+[^🌑]: The Deep Gnome is interchangeably known as a Svirfneblin.

--- a/docs/gnomes.md
+++ b/docs/gnomes.md
@@ -10,7 +10,7 @@
 #### Gnomish Lineages
 | d3 | Ancestry |
 |:-:|:-|
-| 1 | Deep Gnome[^🙈] [^🍄] |
+| 1 | Deep Gnome[^🙈] [^🍄‍🟫] |
 | 2 | Forest Gnome[^📒2️⃣] |
 | 3 | Rock Gnome[^📒2️⃣] |
 
@@ -38,4 +38,5 @@
 [^⚙️]: Source: _Eberron: Rising from the Last War_
 [^🙈]: Source: _Elemental Evil Player's Companion_
 [^📒2️⃣]: Source: _SRD 5.2_
-[^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_, and the Deep Gnome is mechanically equivalent to a Svirfneblin in _Elemental Evil Player's Companion_.
+[^🍄]: The Tinker Gnome of Dragonlance is mechanically equivalent to a Rock Gnome in _SRD 5.2_.
+[^🍄‍🟫]: The Deep Gnome is interchangeably known as a Svirfneblin.


### PR DESCRIPTION
- subdivided footnotes for each species mechanical equivalency note, with one footnote per comparison species