### PR TITLE
added Lupin, updated Dhampir/Hexblood/Reborn source, added Link Validator as GitHub Action

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,0 +1,29 @@
+name: Link Validator
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  link-validator:
+    name: Link Validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get Markdown files
+        id: get-files
+        shell: bash
+        run: |
+          FILES_LIST=$(find docs/ -name "*.md" | sort | tr '\n' ',' | sed 's/,$//')
+          echo "files=$FILES_LIST" >> $GITHUB_OUTPUT
+      - name: Run Link Validator
+        uses: your-ko/link-validator@2.4.0
+        with:
+          files: ${{ steps.get-files.outputs.files}}
+          fileMasks: "*.md"
+          logLevel: warn
+          lookupPath: ./docs

--- a/.link-validator.yaml
+++ b/.link-validator.yaml
@@ -1,0 +1,5 @@
+validators:
+  localPath:
+    enabled: true
+  http:
+    enabled: false

--- a/docs/ch-1-thesis.md
+++ b/docs/ch-1-thesis.md
@@ -29,8 +29,6 @@ Additionally, **a Game Master should be empowered to apply custom weighting of r
 
 ### Separating
 
-**The lineages from _Van Richten's Guide to Ravenloft_ are not considered to be ancestries of a common species.** While they have shared mechanics for character creation or conversion, they have no actual shared origin in lore and thus are treated as separate species.
-
 **Species adapted from other species with no connections in lore are listed as separate entries.** This includes the Flamekin from _Lorwyn: First Light_, which uses the Fire Genasi for its traits but is otherwise narratively unrelated to Genasi. A footnote will list how these adapted species are mechanically connected to their source species.
 
 ### Sourcing
@@ -38,9 +36,9 @@ Additionally, **a Game Master should be empowered to apply custom weighting of r
 **If a species is available in multiple books, one official source will be referenced in a footnote, prioritized by cost and modernity.** The source of choice will be based on the following methodology from highest to lowest priority:
 
 1. _**Owned Beats Unowned.**_ A book on your shelf should always be preferred over one in your shopping cart. This priority cannot be quantified on this table since we don't have access to your purchase history, but the Game Master is the ultimate arbiter over which variant to use when multiples exist, and our general recommendation is to use whatever the GM or a player already owns, so as to avoid seeking out new material just for silly table rolls.
-2. _**Free Beats Paid.**_ Free sources are preferred over materials that must be purchased (e.g. _SRD_ Human over _Player's Handbook_, _Elemental Evil Player's Companion_ Genasi over _Mordenkainen Presents: Monsters of the Multiverse_). This builds on **Owned Beats Unowned**, since these sources cost nothing to add to your personal library. Some of these resources have been discontinued and are no longer available for download from their source sites, but the Internet Archive is a veritable Trove of such treasures.
-3. _**More Beats Fewer.**_ Single sources containing the most species options are preferred over books with fewer options (e.g. _Mordenkainen Presents: Monsters of the Multiverse_ Aasimar over _Volo's Guide to Monsters_).
-4. _**New Beats Old.**_ The most modern sources are preferred over older similar materials that have been superseded by newer releases with updated rules (e.g. _SRD 5.2_ Tiefling over _SRD 5.1_, _Eberron: Forge of the Artificer_ Kalashtar over _Eberron: Rising from the Last War_).
+2. _**Free Beats Paid.**_ Free sources are preferred over materials that must be purchased (e.g. _SRD_'s Human over _Player's Handbook_, _Elemental Evil Player's Companion_'s Genasi over _Mordenkainen Presents: Monsters of the Multiverse_). This builds on **Owned Beats Unowned**, since these sources cost nothing to add to your personal library. Some of these resources have been discontinued and are no longer available for download from their source sites, but the Internet Archive is a veritable Trove of such treasures.
+3. _**More Beats Fewer.**_ Single sources containing the most species options are preferred over books with fewer options (e.g. _Ravenloft: The Horrors Within_'s Hexblood over _Van Richten's Guide to Ravenloft_).
+4. _**New Beats Old.**_ The most modern sources are preferred over older similar materials that have been superseded by newer releases with updated rules (e.g. _SRD 5.2_'s Tiefling over _SRD 5.1_, _Eberron: Forge of the Artificer_'s Kalashtar over _Eberron: Rising from the Last War_).
 
 ### Setting considerations
 

--- a/docs/ch-2-reincarnate.md
+++ b/docs/ch-2-reincarnate.md
@@ -56,27 +56,28 @@ The reincarnated creature makes any choices that a species' description offers, 
 | 35 | Lizardfolk[^👹] |
 | 36 | Locathah[^🐟] |
 | 37 | Loxodon[^🏙️] |
-| 38 | Merfolk (roll on **[Merfolk](merfolk.md)** table for setting) |
-| 39 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
-| 40 | Naga[^☥] |
-| 41 | Orc (roll on **[Orcs](orcs.md)** table for setting) |
-| 42 | Owlin[^🎓] |
-| 43 | Plasmoid[^🛸] |
-| 44 | Rimekin[^🌄] |
-| 45 | Reborn[^🌫️] |
-| 46 | Satyr[^👹] |
-| 47 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
-| 48 | Simic Hybrid[^🏙️] |
-| 49 | Siren[^🦕] |
-| 50 | Tabaxi[^👹] |
-| 51 | Thri-kreen[^🛸] |
-| 52 | Tiefling (roll on **[Tieflings](tieflings.md)** table for setting) |
-| 53 | Tortle[^👹] |
-| 54 | Triton[^👹] |
-| 55 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
-| 56 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
-| 57 | Warforged[^⚒️] |
-| 58 | Yuan-ti[^👹] |
+| 38 | Lupin[^🌫️] |
+| 39 | Merfolk (roll on **[Merfolk](merfolk.md)** table for setting) |
+| 40 | Minotaur (roll on **[Minotaur](#minotaur)** table for ancestry) |
+| 41 | Naga[^☥] |
+| 42 | Orc (roll on **[Orcs](orcs.md)** table for setting) |
+| 43 | Owlin[^🎓] |
+| 44 | Plasmoid[^🛸] |
+| 45 | Rimekin[^🌄] |
+| 46 | Reborn[^🌫️] |
+| 47 | Satyr[^👹] |
+| 48 | Shifter (roll on **[Shifters](#shifters)** table for ancestry) |
+| 49 | Simic Hybrid[^🏙️] |
+| 50 | Siren[^🦕] |
+| 51 | Tabaxi[^👹] |
+| 52 | Thri-kreen[^🛸] |
+| 53 | Tiefling (roll on **[Tieflings](tieflings.md)** table for setting) |
+| 54 | Tortle[^👹] |
+| 55 | Triton[^👹] |
+| 56 | Vampire (roll on **[Vampires](#vampires)** table for ancestry) |
+| 57 | Vedalken (roll on **[Vedalken](#vedalken)** table for ancestry) |
+| 58 | Warforged[^⚒️] |
+| 59 | Yuan-ti[^👹] |
 
 #### Aasimar
 | d5 | Ancestry |
@@ -178,11 +179,11 @@ The reincarnated creature makes any choices that a species' description offers, 
 [^🕰️]: Source: _Plane Shift: Kaladesh_
 [^🌴]: Source: _Plane Shift: Zendikar_
 [^🔰2️⃣]: Source: _Player's Handbook (2024)_
+[^🌫️]: Source: _Ravenloft: The Horrors Within_
 [^🛸]: Source: _Spelljammer: Adventures in Space_
 [^🎓]: Source: _Strixhaven: Curriculum of Chaos_
 [^📒1️⃣]: Source: _SRD 5.1_
 [^📒2️⃣]: Source: _SRD 5.2_
-[^🌫️]: Source: _Van Richten's Guide to Ravenloft_
 [^🪽]: The Aasimar was updated in _Player's Handbook (2024)_ to remove ancestry selection. The Aasimar is not mechanically equivalent to any single prior Aasimar option.
 [^🎭]: The Lorwyn Changeling is mechanically equivalent to a Changeling in _Mordenkainen Presents: Monsters of the Multiverse_.
 [^☄️]: The Flamekin is mechanically equivalent to a Fire Genasi in _Elemental Evil Player's Companion_.

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -50,8 +50,6 @@ _Mythic Odysseys of Theros_ © 2020 Wizards of the Coast LLC.
 
 _Fizban's Treasury of Dragons_ © 2021 Wizards of the Coast LLC.
 
-_Van Richten's Guide to Ravenloft_ © 2021 Wizards of the Coast LLC.
-
 _Dragonlance: Shadow of the Dragon Queen_ © 2022 Wizards of the Coast LLC.
 
 _Mordenkainen Presents: Monsters of the Multiverse_ © 2022 Wizards of the Coast LLC.
@@ -65,6 +63,8 @@ _Eberron: Forge of the Artificer_ © 2025 Wizards of the Coast LLC.
 _Forgotten Realms: Heroes of Faerûn_ © 2025 Wizards of the Coast LLC.
 
 _Lorwyn: First Light_ © 2025 Wizards of the Coast LLC.
+
+_Ravenloft: The Horrors Within_ © 2026 Wizards of the Coast LLC.
 
 ---
 


### PR DESCRIPTION
- added Lupin from _Ravenloft: The Horrors Within_ and added book to Credits
- updated Dhampir, Hexblood, and Reborn sources to _Ravenloft: The Horrors Within_ (More Beats Fewer)
- removed _Van Richten's Guide to Ravenloft_ lineage separation assumption
- removed _Van Richten's Guide to Ravenloft_ from Credits
- added Link Validator as GitHub Action